### PR TITLE
[126772043] Filter descriptions by lot

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -97,37 +97,11 @@ class ContentManifest(object):
         service data. This is calculated by resolving the dependencies
         described by the `depends` section."""
         sections = filter(None, [
-            self._get_section_filtered_by(section, service_data)
+            section.filter(service_data)
             for section in self.sections
         ])
 
         return ContentManifest(sections)
-
-    def _get_section_filtered_by(self, section, service_data):
-        section = section.copy()
-
-        filtered_questions = [
-            question for question in section.questions
-            if self._question_should_be_shown(
-                question.get("depends"), service_data
-            )
-        ]
-
-        if len(filtered_questions):
-            section.questions = filtered_questions
-            return section
-        else:
-            return None
-
-    def _question_should_be_shown(self, dependencies, service_data):
-        if dependencies is None:
-            return True
-        for depends in dependencies:
-            if not depends["on"] in service_data:
-                return False
-            if not service_data[depends["on"]] in depends["being"]:
-                return False
-        return True
 
     def get_question(self, field_name):
         for section in self.sections:
@@ -325,6 +299,32 @@ class ContentSection(object):
     def inject_brief_questions_into_boolean_list_question(self, brief):
         for question in self.questions:
             question.inject_brief_questions_into_boolean_list_question(brief)
+
+    def filter(self, service_data):
+        section = self.copy()
+
+        filtered_questions = [
+            question for question in section.questions
+            if self._question_should_be_shown(
+                question.get("depends"), service_data
+            )
+        ]
+
+        if len(filtered_questions):
+            section.questions = filtered_questions
+            return section
+        else:
+            return None
+
+    def _question_should_be_shown(self, dependencies, service_data):
+        if dependencies is None:
+            return True
+        for depends in dependencies:
+            if not depends["on"] in service_data:
+                return False
+            if not service_data[depends["on"]] in depends["being"]:
+                return False
+        return True
 
     # Type checking
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -628,6 +628,65 @@ class TestContentSection(object):
 
         return section, brief, form
 
+    def test_filtering_a_section_with_a_description_dictionary(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q1",
+                "question": 'First question'
+            }],
+            "description": {
+                "default": "default description",
+                "digital-specialists": "description just for digital specialists",
+                "digital-outcomes": "description just for digital outcomes"
+            }
+        })
+
+        assert section.filter({"lot": "digital-specialists"}).description == "description just for digital specialists"
+        assert section.filter({"lot": "digital-outcomes"}).description == "description just for digital outcomes"
+        assert section.filter({"lot": "user-research-studios"}).description == "default description"
+
+    def test_filtering_a_section_with_a_description_dictionary_with_no_default_and_unknown_key_raises_error(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [],
+            "description": {
+                "digital-specialists": "description just for digital specialists",
+                "digital-outcomes": "description just for digital outcomes"
+            }
+        })
+        with pytest.raises(KeyError):
+            section.filter({"lot": "user-research-participants"})
+
+    def test_filtering_a_section_with_a_description_string_does_not_affect_the_description(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "q1",
+                "question": 'First question'
+            }],
+            "description": "just a string"
+        })
+
+        assert section.filter({"lot": "digital-specialists"}).description == "just a string"
+
+    def test_get_section_description_which_is_dictionary_raises_error(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [],
+            "description": {
+                "digital-specialists": "description just for digital specialists",
+                "digital-outcomes": "description just for digital outcomes"
+            }
+        })
+
+        with pytest.raises(TypeError):
+            section.description
+
     def test_has_summary_page_if_multiple_questions(self):
         section = ContentSection.create({
             "slug": "first_section",


### PR DESCRIPTION
### Reason and background information for this pull request
[Original story](https://www.pivotaltracker.com/story/show/122114497) was a small content change however the only way to do it was to introduce filtering descriptions by lot to the content loader (for which [this new story](https://www.pivotaltracker.com/story/show/126772043) was added).

First, a YAML schema was decided and added to the frameworks repository. [This PR](https://github.com/alphagov/digitalmarketplace-frameworks/pull/293) includes full details of the new schema. Examples of new schema:

```
description: Buyers will use the information suppliers provide here to create a shortlist.
```
or 
```
description:
    default: Buyers will use the information suppliers provide here to create a shortlist.
    digital-specialists: You can only offer 1 specialist for this opportunity. Buyers will use the information suppliers provide here to create a shortlist.
```

### In this pull request
- When provided with a `description` which is a dictionary of lot keys, we are able to filter this dictionary by lot. If a lot key is not found then we can fall back to the `default` key. If no `default` key exists in `description`, then we raise an error.
- Introduced description as a `@property` so we can raise an error if we try to access the description but it has not yet been filtered to it's chosen string.
- Existing behaviour of parsing a description which is a string or is `None` is not changed.
- Bumps version to 1.2.0
- Small refactor to move methods from `ContentManifest` to `ContentSection` class as they better belong there

### In particular, looking for any feedback on
- errors raised (if they could be subclassed etc)
