### PR TITLE
[#131733667] Content loader to support Jinja templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ These are the fields that are turned into TemplateFields when the YAML files are
 |-----------------------------------|----------------------------------------------------|
 | [`name`, `description`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/content_loader.py#L123) | [`question`, `name`, `question_advice`, `hint`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/questions.py#L10) |
 
+In addition, all string fields (including fields in lists and nested dictionaries) in content
+messages are turned into TemplateFields.
+
 [ContentTemplateError](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/errors.py#L8)s are raised if a TemplateField is accessed (ie, [rendered](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/content_loader.py#L166-L167)) without
 the variables it needs.  Although we don't have a way to verify that every templated
 field gets all of the variables it expects in every case (we would only know
@@ -31,6 +34,8 @@ HTML and jinja logic is escaped before it is presented to the user.
 
 Nothing that is currently working will break with this update, so the example
 below shows how a previously static field can now be given a variable.
+
+This change also removes support for the unused `sub_key` argument to `ContentLoader.get_message`.
 
 ### Example app change
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,84 @@
 
 Records breaking changes from major version bumps
 
+## 2.0.0
+
+PR: [#8](https://github.com/alphagov/digitalmarketplace-apiclient/pull/8)
+
+### What changed
+
+Before, all values in YAML files were stored as strings and then printed out
+directly by jinja in the frontend apps.  Now, we're creating [TemplateField](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/utils.py#L8)s
+for specific attibutes of questions and sections.  TemplateFields are wrappers
+around jinja [Templates](http://jinja.pocoo.org/docs/dev/api/#jinja2.Template) that are passed an initial string and then are rendered
+with a context.
+The result of all this is that we can pass variables to our content which
+come from briefs or lots or service data or whatever else, either to be
+printed as part of the content or evaluated as part of some logic operation.
+
+These are the fields that are turned into TemplateFields when the YAML files are loaded:
+
+| ContentSection                    | Question                                           |
+|-----------------------------------|----------------------------------------------------|
+| [`name`, `description`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/content_loader.py#L123) | [`question`, `name`, `question_advice`, `hint`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/questions.py#L10) |
+
+[ContentTemplateError](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/errors.py#L8)s are raised if a TemplateField is accessed (ie, [rendered](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/content_loader.py#L166-L167)) without
+the variables it needs.  Although we don't have a way to verify that every templated
+field gets all of the variables it expects in every case (we would only know
+this for sure in the view logic in the frontend apps), we have tests to make sure
+HTML and jinja logic is escaped before it is presented to the user.
+
+Nothing that is currently working will break with this update, so the example
+below shows how a previously static field can now be given a variable.
+
+### Example app change
+
+#### Old
+```yml
+# digitalmarketplace-frameworks/frameworks/digital-outcomes-and-specialists/manifests/edit_brief_response.yml
+name: Apply for this opportunity
+```
+
+```python
+# digitalmarketplace-supplier-frontend/app/main/views/briefs.py
+def create_brief_response(brief_id):
+  section = manifest.get_section('apply').filter({})
+  return render_template(section=section)
+```
+
+```jinja
+<!-- digitalmarketplace-supplier-frontend/app/templates/briefs/brief_response.html -->
+<h1>{{ section.name }}</h1>
+```
+
+```html
+<!-- Output -->
+<h1>Apply for this opportunity</h1>
+```
+
+#### New
+```yml
+# digitalmarketplace-frameworks/frameworks/digital-outcomes-and-specialists/manifests/edit_brief_response.yml
+name: Apply for ‘{{ brief.title }}’
+```
+
+```python
+# digitalmarketplace-supplier-frontend/app/main/views/briefs.py
+def create_brief_response(brief_id):
+  section = manifest.get_section('apply').filter({'brief': brief})
+  return render_template(section=section)
+```
+
+```jinja
+<!-- digitalmarketplace-supplier-frontend/app/templates/briefs/brief_response.html -->
+<h1>{{ section.name }}</h1>
+```
+
+```html
+<!-- Output -->
+<h1>Apply for ‘Home Office IPT Programme Caseworking and DPM Delivery Partner’</h1>
+```
+
 ## 1.0.0
 
 PR: [#1](https://github.com/alphagov/digitalmarketplace-apiclient/pull/1)

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '1.3.0'
+__version__ = '2.0.0'

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -1,5 +1,5 @@
 from .content_loader import ContentLoader
-from .errors import QuestionNotFoundError
+from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
 __version__ = '1.3.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -316,12 +316,10 @@ class ContentSection(object):
         section = self.copy()
         section._filtered = True
 
-        filtered_questions = [
-            question for question in section.questions
-            if self._question_should_be_shown(
-                question.get("depends"), context
-            )
-        ]
+        filtered_questions = list(filter(None, [
+            question.filter(context)
+            for question in self.questions
+        ]))
 
         if not filtered_questions:
             return None
@@ -337,16 +335,6 @@ class ContentSection(object):
         section.questions = filtered_questions
 
         return section
-
-    def _question_should_be_shown(self, dependencies, context):
-        if dependencies is None:
-            return True
-        for depends in dependencies:
-            if not depends["on"] in context:
-                return False
-            if not context[depends["on"]] in depends["being"]:
-                return False
-        return True
 
     # Type checking
 

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -404,7 +404,7 @@ class ContentLoader(object):
 
     def get_question(self, framework_slug, question_set, question):
         if question in self._questions.get(framework_slug, {}).get(question_set, {}):
-            return
+            return self._questions[framework_slug][question_set][question].copy()
 
         try:
             questions_path = self._questions_path(framework_slug, question_set)

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -320,6 +320,9 @@ class ContentSection(object):
             )
         ]
 
+        if not filtered_questions:
+            return None
+
         # Filter description by lot
         if isinstance(self._description, dict) and service_data.get('lot'):
             if self._description.get(service_data['lot']):
@@ -334,11 +337,9 @@ class ContentSection(object):
         env = SandboxedEnvironment(autoescape=True, undefined=StrictUndefined)
         section.name = env.from_string(section.name).render(**service_data)
 
-        if len(filtered_questions):
-            section.questions = filtered_questions
-            return section
-        else:
-            return None
+        section.questions = filtered_questions
+
+        return section
 
     def _question_should_be_shown(self, dependencies, service_data):
         if dependencies is None:

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -8,6 +8,8 @@ from collections import defaultdict, OrderedDict
 from functools import partial
 from six import string_types
 from werkzeug.datastructures import ImmutableMultiDict
+from jinja2 import StrictUndefined
+from jinja2.sandbox import SandboxedEnvironment
 
 from .errors import ContentNotFoundError, QuestionNotFoundError
 from .questions import ContentQuestion
@@ -328,6 +330,9 @@ class ContentSection(object):
                 raise KeyError
 
             section._description = filtered_description
+
+        env = SandboxedEnvironment(autoescape=True, undefined=StrictUndefined)
+        section.name = env.from_string(section.name).render(**service_data)
 
         if len(filtered_questions):
             section.questions = filtered_questions

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -9,10 +9,8 @@ import copy
 from collections import defaultdict, OrderedDict
 from functools import partial
 from werkzeug.datastructures import ImmutableMultiDict
-from jinja2 import StrictUndefined, UndefinedError
-from jinja2.sandbox import SandboxedEnvironment
 
-from .errors import ContentNotFoundError, ContentTemplateError, QuestionNotFoundError
+from .errors import ContentNotFoundError, QuestionNotFoundError
 from .questions import Question, ContentQuestion
 from .utils import TemplateField
 
@@ -166,10 +164,7 @@ class ContentSection(object):
         context = object.__getattribute__(self, '_context')
         field = object.__getattribute__(self, key)
         if isinstance(field, TemplateField):
-            try:
-                return field.render(context)
-            except UndefinedError as e:
-                raise ContentTemplateError(e.message)
+            return field.render(context)
         else:
             return field
 

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -13,7 +13,7 @@ from jinja2 import StrictUndefined
 from jinja2.sandbox import SandboxedEnvironment
 
 from .errors import ContentNotFoundError, QuestionNotFoundError
-from .questions import ContentQuestion
+from .questions import Question, ContentQuestion
 from .utils import TemplateField
 
 
@@ -405,7 +405,7 @@ class ContentLoader(object):
     def _process_section(self, framework_slug, question_set, section):
         section = self._load_nested_questions(framework_slug, question_set, section)
 
-        for field in ['name', 'description']:
+        for field in ContentSection.TEMPLATE_FIELDS:
             if field in section:
                 section[field] = TemplateField(section[field])
 
@@ -424,7 +424,7 @@ class ContentLoader(object):
         except IOError:
             raise ContentNotFoundError("No question {} at {}".format(question, questions_path))
 
-        for field in ['name', 'question', 'hint', 'question_advice']:
+        for field in Question.TEMPLATE_FIELDS:
             if field in question_data:
                 question_data[field] = TemplateField(question_data[field])
 

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -504,4 +504,4 @@ def _make_slug(name):
 
 def read_yaml(yaml_file):
     with open(yaml_file, "r") as file:
-        return yaml.load(file)
+        return yaml.safe_load(file)

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -152,7 +152,7 @@ class ContentSection(object):
         self.editable = editable
         self.edit_questions = edit_questions
         self.questions = questions
-        self._description = description
+        self.description = description
         self.summary_page_description = summary_page_description
         self.step = step
 
@@ -166,16 +166,9 @@ class ContentSection(object):
             editable=self.editable,
             edit_questions=self.edit_questions,
             questions=self.questions[:],
-            description=self._description,
+            description=self.description,
             summary_page_description=self.summary_page_description,
             step=self.step)
-
-    @property
-    def description(self):
-        if isinstance(self._description, string_types) or self._description is None:
-            return self._description
-        else:
-            raise TypeError('_description is not a string or not None')
 
     def summary(self, service_data):
         summary_section = self.copy()
@@ -323,19 +316,8 @@ class ContentSection(object):
         if not filtered_questions:
             return None
 
-        # Filter description by lot
-        if isinstance(self._description, dict) and context.get('lot'):
-            if self._description.get(context['lot']):
-                filtered_description = self._description.get(context['lot'])
-            elif self._description.get('default'):
-                filtered_description = self._description.get('default')
-            else:
-                raise KeyError
-
-            section._description = filtered_description
-
         env = SandboxedEnvironment(autoescape=True, undefined=StrictUndefined)
-        for section_field in ['name', '_description']:
+        for section_field in ['name', 'description']:
             setattr(
                 section,
                 section_field,

--- a/dmcontent/errors.py
+++ b/dmcontent/errors.py
@@ -5,5 +5,9 @@ class ContentNotFoundError(Exception):
     pass
 
 
+class ContentTemplateError(Exception):
+    pass
+
+
 class QuestionNotFoundError(Exception):
     pass

--- a/dmcontent/messages.py
+++ b/dmcontent/messages.py
@@ -1,0 +1,45 @@
+from dmcontent.utils import TemplateField
+
+
+class ContentMessage(object):
+    def __init__(self, data, _context=None):
+        self._data = data.copy()
+        self._context = _context
+
+    def filter(self, context):
+        message = ContentMessage(self._data)
+        message._context = context
+
+        return message
+
+    def get(self, key, default=None):
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            return default
+
+    def __eq__(self, other):
+        if not isinstance(other, ContentMessage):
+            return False
+        return (self._data == other._data) and (self._context == other._context)
+
+    def __getattr__(self, key):
+        try:
+            field = self._data[key]
+        except KeyError:
+            raise AttributeError(key)
+
+        if isinstance(field, TemplateField):
+            return field.render(self._context)
+        elif isinstance(field, dict):
+            return ContentMessage(field, _context=self._context)
+        elif isinstance(field, list):
+            return [i.render(self._context) for i in field]
+        else:
+            return field
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __repr__(self):
+        return '<{0.__class__.__name__}: data={0._data}>'.format(self)

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -167,12 +167,13 @@ class Question(object):
     def __getattr__(self, key):
         try:
             field = self._data[key]
-            if isinstance(field, TemplateField):
-                return field.render(self._context)
-            else:
-                return field
         except KeyError:
             raise AttributeError(key)
+
+        if isinstance(field, TemplateField):
+            return field.render(self._context)
+        else:
+            return field
 
     def __getitem__(self, key):
         return getattr(self, key)
@@ -286,6 +287,7 @@ class QuestionSummary(Question):
         self.number = question.number
         self._data = question._data
         self._service_data = service_data
+        self._context = question._context
 
         if question.get('boolean_list_questions'):
             self.boolean_list_questions = question.boolean_list_questions

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -9,7 +9,7 @@ from .formats import format_price
 
 
 class Question(object):
-    TEMPLATE_FIELDS = ['question', 'hint', 'question_advice']
+    TEMPLATE_FIELDS = ['name', 'question', 'hint', 'question_advice']
 
     def __init__(self, data, number=None):
         self.number = number

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -13,6 +13,18 @@ class Question(object):
     def summary(self, service_data):
         return QuestionSummary(self, service_data)
 
+    def filter(self, context):
+        if not self._should_be_shown(context):
+            return None
+
+        return ContentQuestion(self._data, number=self.number)
+
+    def _should_be_shown(self, context):
+        return all(
+            depends["on"] in context and (context[depends["on"]] in depends["being"])
+            for depends in self.get("depends", [])
+        )
+
     def get_question(self, field_name):
         if self.id == field_name:
             return self

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -1,6 +1,9 @@
+import collections
+
 from jinja2 import Markup, StrictUndefined, TemplateSyntaxError, UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 from markdown import markdown
+from six import string_types
 
 from .errors import ContentTemplateError
 
@@ -35,3 +38,17 @@ class TemplateField(object):
 
     def __repr__(self):
         return '<{0.__class__.__name__}: "{0._field_value}">'.format(self)
+
+
+def template_all(item):
+    if isinstance(item, string_types):
+        return TemplateField(item)
+    elif isinstance(item, collections.Sequence):
+        return [template_all(i) for i in item]
+    elif isinstance(item, collections.Mapping):
+        result = {}
+        for (key, val) in item.items():
+            result[key] = template_all(val)
+        return result
+    else:
+        return item

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -1,0 +1,21 @@
+from jinja2 import StrictUndefined
+from jinja2.sandbox import SandboxedEnvironment
+
+
+class TemplateField(object):
+    def __init__(self, field_value):
+        env = SandboxedEnvironment(autoescape=True, undefined=StrictUndefined)
+        self._field_value = field_value
+        self.template = env.from_string(field_value)
+        self.context = {}
+
+    def render(self):
+        return self.template.render(self.context)
+
+    def __eq__(self, other):
+        if not isinstance(other, TemplateField):
+            return False
+        return (self._field_value == other._field_value) and (self.context == other.context)
+
+    def __repr__(self):
+        return '<{0.__class__.__name__}: "{0._field_value}", context={0.context}>'.format(self)

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -7,15 +7,14 @@ class TemplateField(object):
         env = SandboxedEnvironment(autoescape=True, undefined=StrictUndefined)
         self._field_value = field_value
         self.template = env.from_string(field_value)
-        self.context = {}
 
-    def render(self):
-        return self.template.render(self.context)
+    def render(self, context=None):
+        return self.template.render(context or {})
 
     def __eq__(self, other):
         if not isinstance(other, TemplateField):
             return False
-        return (self._field_value == other._field_value) and (self.context == other.context)
+        return (self._field_value == other._field_value)
 
     def __repr__(self):
-        return '<{0.__class__.__name__}: "{0._field_value}", context={0.context}>'.format(self)
+        return '<{0.__class__.__name__}: "{0._field_value}">'.format(self)

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -1,5 +1,7 @@
-from jinja2 import StrictUndefined
+from jinja2 import StrictUndefined, UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
+
+from .errors import ContentTemplateError
 
 
 class TemplateField(object):
@@ -9,7 +11,10 @@ class TemplateField(object):
         self.template = env.from_string(field_value)
 
     def render(self, context=None):
-        return self.template.render(context or {})
+        try:
+            return self.template.render(context or {})
+        except UndefinedError as e:
+            raise ContentTemplateError(e.message)
 
     def __eq__(self, other):
         if not isinstance(other, TemplateField):

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -1,4 +1,4 @@
-from jinja2 import StrictUndefined, UndefinedError, TemplateSyntaxError
+from jinja2 import Markup, StrictUndefined, TemplateSyntaxError, UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 from markdown import markdown
 
@@ -24,7 +24,7 @@ class TemplateField(object):
 
     def render(self, context=None):
         try:
-            return self.template.render(context or {})
+            return Markup(self.template.render(context or {}))
         except UndefinedError as e:
             raise ContentTemplateError(e.message)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML==3.11
 Werkzeug==0.11.9
 six==1.10.0
 Jinja2==2.8
+Markdown==2.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ inflection==0.3.1
 PyYAML==3.11
 Werkzeug==0.11.9
 six==1.10.0
+Jinja2==2.8

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -651,7 +651,10 @@ class TestContentSection(object):
         section = ContentSection.create({
             "slug": "first_section",
             "name": "First section",
-            "questions": [],
+            "questions": [{
+                "id": "q1",
+                "question": 'First question'
+            }],
             "description": {
                 "digital-specialists": "description just for digital specialists",
                 "digital-outcomes": "description just for digital outcomes"

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -653,7 +653,7 @@ class TestContentSection(object):
                 "question": "Boolean question",
                 "type": "boolean",
             }]
-        })
+        }).filter({})
         assert section.has_summary_page is False
 
     def test_has_summary_page_if_single_question_with_description(self):
@@ -666,7 +666,7 @@ class TestContentSection(object):
                 "question": "Boolean question",
                 "type": "boolean",
             }]
-        })
+        }).filter({})
         assert section.has_summary_page is True
 
     def test_get_question_ids(self):
@@ -729,7 +729,7 @@ class TestContentSection(object):
                     }
                 ]
             }]
-        })
+        }).filter({})
 
         question_section = section.get_question_as_section('q0-slug')
         assert question_section.name == "Q0"
@@ -1360,10 +1360,10 @@ class TestContentSection(object):
         section = ContentSection.create({
             "slug": "first_section",
             "name": "First section",
-            "questions": [],
+            "questions": [{"id": "q1", "question": "Why?", "type": "text"}],
             "description": "This is the first section",
             "summary_page_description": "This is a summary of the first section"
-        })
+        }).filter({})
         assert section.description == "This is the first section"
         assert section.summary_page_description == "This is a summary of the first section"
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -6,6 +6,7 @@ import pytest
 
 import io
 
+from dmcontent.utils import TemplateField
 from dmcontent.content_loader import (
     ContentLoader, ContentSection, ContentQuestion, ContentManifest,
     read_yaml, ContentNotFoundError, QuestionNotFoundError, _make_slug
@@ -1481,17 +1482,17 @@ class TestContentLoader(object):
         sections = yaml_loader.load_manifest('framework-slug', 'question-set', 'my-manifest')
 
         assert sections == [
-            {'name': 'section1',
+            {'name': TemplateField("section1"),
                 'questions': [
                     {'depends': [{'being': 'SaaS', 'on': 'lot'}],
-                     'name': 'question1', 'id': 'question1'},
+                     'name': TemplateField('question1'), 'id': 'question1'},
                     {'depends': [{'being': 'SaaS', 'on': 'lot'}],
-                     'name': 'question2', 'id': 'q2'}],
+                     'name': TemplateField('question2'), 'id': 'q2'}],
                 'slug': 'section1'},
-            {'name': 'section2',
+            {'name': TemplateField('section2'),
              'questions': [
                  {'depends': [{'being': 'IaaS', 'on': 'lot'}],
-                  'name': 'question3', 'id': 'question3'}],
+                  'name': TemplateField('question3'), 'id': 'question3'}],
              'slug': 'section-2'}
         ]
         read_yaml_mock.assert_has_calls([
@@ -1526,7 +1527,7 @@ class TestContentLoader(object):
 
         assert yaml_loader.get_question('framework-slug', 'question-set', 'question1') == {
             'depends': [{'being': 'SaaS', 'on': 'lot'}],
-            'name': 'question1', 'id': 'question1'
+            'name': TemplateField('question1'), 'id': 'question1'
         }
         read_yaml_mock.assert_called_with(
             'content/frameworks/framework-slug/questions/question-set/question1.yml')
@@ -1538,7 +1539,7 @@ class TestContentLoader(object):
 
         assert yaml_loader.get_question('framework-slug', 'question-set', 'question2') == {
             'depends': [{'being': 'SaaS', 'on': 'lot'}],
-            'name': 'question2', 'id': 'q2'
+            'name': TemplateField('question2'), 'id': 'q2'
         }
         read_yaml_mock.assert_called_with(
             'content/frameworks/framework-slug/questions/question-set/question2.yml')

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1501,6 +1501,16 @@ class TestContentLoader(object):
             mock.call('content/frameworks/framework-slug/questions/question-set/question2.yml'),
         ])
 
+    def test_manifest_loading_cache(self, read_yaml_mock):
+        self.set_read_yaml_mock_response(read_yaml_mock)
+
+        yaml_loader = ContentLoader('content/')
+
+        yaml_loader.load_manifest('framework-slug', 'question-set', 'my-manifest')
+        yaml_loader.load_manifest('framework-slug', 'question-set', 'my-manifest')
+
+        assert read_yaml_mock.call_count == 4
+
     def test_manifest_loading_fails_if_manifest_cannot_be_read(self, read_yaml_mock):
         read_yaml_mock.side_effect = IOError
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -628,68 +628,6 @@ class TestContentSection(object):
 
         return section, brief, form
 
-    def test_filtering_a_section_with_a_description_dictionary(self):
-        section = ContentSection.create({
-            "slug": "first_section",
-            "name": "First section",
-            "questions": [{
-                "id": "q1",
-                "question": 'First question'
-            }],
-            "description": {
-                "default": "default description",
-                "digital-specialists": "description just for digital specialists",
-                "digital-outcomes": "description just for digital outcomes"
-            }
-        })
-
-        assert section.filter({"lot": "digital-specialists"}).description == "description just for digital specialists"
-        assert section.filter({"lot": "digital-outcomes"}).description == "description just for digital outcomes"
-        assert section.filter({"lot": "user-research-studios"}).description == "default description"
-
-    def test_filtering_a_section_with_a_description_dictionary_with_no_default_and_unknown_key_raises_error(self):
-        section = ContentSection.create({
-            "slug": "first_section",
-            "name": "First section",
-            "questions": [{
-                "id": "q1",
-                "question": 'First question'
-            }],
-            "description": {
-                "digital-specialists": "description just for digital specialists",
-                "digital-outcomes": "description just for digital outcomes"
-            }
-        })
-        with pytest.raises(KeyError):
-            section.filter({"lot": "user-research-participants"})
-
-    def test_filtering_a_section_with_a_description_string_does_not_affect_the_description(self):
-        section = ContentSection.create({
-            "slug": "first_section",
-            "name": "First section",
-            "questions": [{
-                "id": "q1",
-                "question": 'First question'
-            }],
-            "description": "just a string"
-        })
-
-        assert section.filter({"lot": "digital-specialists"}).description == "just a string"
-
-    def test_get_section_description_which_is_dictionary_raises_error(self):
-        section = ContentSection.create({
-            "slug": "first_section",
-            "name": "First section",
-            "questions": [],
-            "description": {
-                "digital-specialists": "description just for digital specialists",
-                "digital-outcomes": "description just for digital outcomes"
-            }
-        })
-
-        with pytest.raises(TypeError):
-            section.description
-
     def test_has_summary_page_if_multiple_questions(self):
         section = ContentSection.create({
             "slug": "first_section",

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -46,3 +46,27 @@ class TestFilterContentSection(object):
         )
 
         assert section.filter({'name': 'one'}).name == 'Section one'
+
+    def test_section_description_is_templated(self):
+        section = ContentSection(
+            slug='section',
+            name='Section one',
+            editable=False,
+            edit_questions=False,
+            questions=[Question({})],
+            description="This is the {{ name }} section"
+        )
+
+        assert section.filter({'name': 'first'}).description == 'This is the first section'
+
+    def test_section_description_is_not_set(self):
+        section = ContentSection(
+            slug='section',
+            name='Section one',
+            editable=False,
+            edit_questions=False,
+            questions=[Question({})],
+            description=None
+        )
+
+        assert section.filter({}).description == None

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -1,0 +1,48 @@
+from dmcontent.questions import Question
+from dmcontent.content_loader import ContentSection
+
+
+class TestFilterContentSection(object):
+    def test_fields_without_template_tags_are_unchanged(self):
+        section = ContentSection(
+            slug='section',
+            name='Section',
+            editable=False,
+            edit_questions=False,
+            questions=[Question({})]
+        )
+
+        assert section.filter({}).name == 'Section'
+
+    def test_question_fields_without_template_tags_are_unchanged(self):
+        section = ContentSection(
+            slug='section',
+            name='Section',
+            editable=False,
+            edit_questions=False,
+            questions=[Question({'name': 'Question'})]
+        )
+
+        assert section.filter({}).questions[0].name == 'Question'
+
+    def test_not_all_fields_are_templated(self):
+        section = ContentSection(
+            slug='# {{ section }}',
+            name='Section',
+            editable=False,
+            edit_questions=False,
+            questions=[Question({})]
+        )
+
+        assert section.filter({}).slug == '# {{ section }}'
+
+    def test_section_name_is_templated(self):
+        section = ContentSection(
+            slug='section',
+            name='Section {{ name }}',
+            editable=False,
+            edit_questions=False,
+            questions=[Question({})]
+        )
+
+        assert section.filter({'name': 'one'}).name == 'Section one'

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -1,16 +1,18 @@
 import pytest
 from jinja2 import UndefinedError
 
+from dmcontent.utils import TemplateField
 from dmcontent.questions import Question, Multiquestion
 from dmcontent.content_loader import ContentSection
+from dmcontent import ContentTemplateError
 
 
 class TestFilterContentSection(object):
     def test_fields_without_template_tags_are_unchanged(self):
         section = ContentSection(
             slug='section',
-            name='Section',
-            description='just a string',
+            name=TemplateField('Section'),
+            description=TemplateField('just a string'),
             editable=False,
             edit_questions=False,
             questions=[Question({})]
@@ -22,7 +24,7 @@ class TestFilterContentSection(object):
     def test_question_fields_without_template_tags_are_unchanged(self):
         section = ContentSection(
             slug='section',
-            name='Section',
+            name=TemplateField('Section'),
             editable=False,
             edit_questions=False,
             questions=[Question({'name': 'Question'})]
@@ -33,7 +35,7 @@ class TestFilterContentSection(object):
     def test_not_all_fields_are_templated(self):
         section = ContentSection(
             slug='# {{ section }}',
-            name='Section',
+            name=TemplateField('Section'),
             editable=False,
             edit_questions=False,
             questions=[Question({})]
@@ -44,19 +46,19 @@ class TestFilterContentSection(object):
     def test_missing_context_variable_raises_an_error(self):
         section = ContentSection(
             slug='section',
-            name='Section {{ name }}',
+            name=TemplateField('Section {{ name }}'),
             editable=False,
             edit_questions=False,
             questions=[Question({})]
         )
 
-        with pytest.raises(UndefinedError):
+        with pytest.raises(ContentTemplateError):
             section.filter({}).name
 
     def test_section_name_is_templated(self):
         section = ContentSection(
             slug='section',
-            name='Section {{ name }}',
+            name=TemplateField('Section {{ name }}'),
             editable=False,
             edit_questions=False,
             questions=[Question({})]
@@ -67,7 +69,7 @@ class TestFilterContentSection(object):
     def test_unused_context_variables_are_ignored(self):
         section = ContentSection(
             slug='section',
-            name='Section {{ name }}',
+            name=TemplateField('Section {{ name }}'),
             editable=False,
             edit_questions=False,
             questions=[Question({})]
@@ -78,11 +80,11 @@ class TestFilterContentSection(object):
     def test_section_description_is_templated(self):
         section = ContentSection(
             slug='section',
-            name='Section one',
+            name=TemplateField('Section one'),
             editable=False,
             edit_questions=False,
             questions=[Question({})],
-            description="This is the {{ name }} section"
+            description=TemplateField("This is the {{ name }} section")
         )
 
         assert section.filter({'name': 'first'}).description == 'This is the first section'
@@ -90,29 +92,28 @@ class TestFilterContentSection(object):
     def test_section_description_is_not_set(self):
         section = ContentSection(
             slug='section',
-            name='Section one',
+            name=TemplateField('Section one'),
             editable=False,
             edit_questions=False,
-            questions=[Question({})],
-            description=None
+            questions=[Question({})]
         )
 
         assert section.filter({}).description is None
 
-    def test_get_templatable_section_attributes_before_filter_raises_error(self):
+    def test_get_templatable_section_attributes_calls_render(self):
         section = ContentSection(
             slug='section',
-            name='Section one',
+            name=TemplateField('{% if True %}Section one{% else %}Section two{% endif %}'),
             editable=False,
             edit_questions=False,
             questions=[Question({})],
-            description="description for {% if lot == 'digital-specialists' %}specialists{% else %}outcomes{% endif %}"
+            description=TemplateField(
+                "description for {% if lot == 'digital-specialists' %}specialists{% else %}outcomes{% endif %}"
+            )
         )
 
-        with pytest.raises(TypeError):
-            section.name
-
-        with pytest.raises(TypeError):
+        assert section.name == 'Section one'
+        with pytest.raises(ContentTemplateError):
             section.description
 
         assert section.slug == 'section'
@@ -120,15 +121,15 @@ class TestFilterContentSection(object):
     def test_copying_section_preserves_value_of_filtered_attribute(self):
         section = ContentSection(
             slug='section',
-            name='Section',
+            name=TemplateField('Section'),
             editable=False,
             edit_questions=False,
             questions=[Question({'name': 'Question'})]
-        ).filter({})
-        assert section._filtered
+        ).filter({'context': 'context1'})
+        assert section._context == {'context': 'context1'}
 
         copied_section = section.copy()
-        assert copied_section._filtered
+        assert copied_section._context == section._context
 
     def test_getting_a_multiquestion_as_a_section_preserves_value_of_filtered_attribute(self):
         multiquestion_data = {
@@ -150,23 +151,27 @@ class TestFilterContentSection(object):
 
         section = ContentSection(
             slug='section',
-            name='Section',
+            name=TemplateField('Section'),
             editable=False,
             edit_questions=False,
             questions=[Multiquestion(multiquestion_data)]
         )
 
-        assert not section.get_question_as_section('example')._filtered
-        assert section.filter({}).get_question_as_section('example')._filtered
+        assert section.get_question_as_section('example')._context is None
+        assert section.filter(
+            {'context': 'context1'}
+        ).get_question_as_section('example')._context == {'context': 'context1'}
 
     def test_filtering_a_section_with_a_description_template(self):
         section = ContentSection(
             slug='section',
-            name='Section one',
+            name=TemplateField('Section one'),
             editable=False,
             edit_questions=False,
             questions=[Question({})],
-            description="description for {% if lot == 'digital-specialists' %}specialists{% else %}outcomes{% endif %}"
+            description=TemplateField(
+                "description for {% if lot == 'digital-specialists' %}specialists{% else %}outcomes{% endif %}"
+            )
         )
 
         assert section.filter({"lot": "digital-specialists"}).description == "description for specialists"

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -1,7 +1,7 @@
 import pytest
 from jinja2 import UndefinedError
 
-from dmcontent.questions import Question
+from dmcontent.questions import Question, Multiquestion
 from dmcontent.content_loader import ContentSection
 
 
@@ -99,7 +99,7 @@ class TestFilterContentSection(object):
 
         assert section.filter({}).description is None
 
-    def test_get_section_description_before_filter_raises_error(self):
+    def test_get_templatable_section_attributes_before_filter_raises_error(self):
         section = ContentSection(
             slug='section',
             name='Section one',
@@ -110,7 +110,54 @@ class TestFilterContentSection(object):
         )
 
         with pytest.raises(TypeError):
+            section.name
+
+        with pytest.raises(TypeError):
             section.description
+
+        assert section.slug == 'section'
+
+    def test_copying_section_preserves_value_of_filtered_attribute(self):
+        section = ContentSection(
+            slug='section',
+            name='Section',
+            editable=False,
+            edit_questions=False,
+            questions=[Question({'name': 'Question'})]
+        ).filter({})
+        assert section._filtered
+
+        copied_section = section.copy()
+        assert copied_section._filtered
+
+    def test_getting_a_multiquestion_as_a_section_preserves_value_of_filtered_attribute(self):
+        multiquestion_data = {
+            "id": "example",
+            "slug": "example",
+            "question": "Example question",
+            "type": "multiquestion",
+            "questions": [
+                {
+                    "id": "example2",
+                    "type": "text",
+                },
+                {
+                    "id": "example3",
+                    "type": "number",
+                }
+            ]
+        }
+
+        section = ContentSection(
+            slug='section',
+            name='Section',
+            editable=False,
+            edit_questions=False,
+            questions=[Multiquestion(multiquestion_data)]
+        )
+
+        assert not section.get_question_as_section('example')._filtered
+        assert section.filter({}).get_question_as_section('example')._filtered
 
     def test_filtering_a_section_with_a_description_template(self):
         section = ContentSection(

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -1,5 +1,4 @@
 import pytest
-from jinja2 import UndefinedError
 
 from dmcontent.utils import TemplateField
 from dmcontent.questions import Question, Multiquestion
@@ -118,7 +117,7 @@ class TestFilterContentSection(object):
 
         assert section.slug == 'section'
 
-    def test_copying_section_preserves_value_of_filtered_attribute(self):
+    def test_copying_section_preserves_value_of_context_attribute(self):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section'),
@@ -131,7 +130,7 @@ class TestFilterContentSection(object):
         copied_section = section.copy()
         assert copied_section._context == section._context
 
-    def test_getting_a_multiquestion_as_a_section_preserves_value_of_filtered_attribute(self):
+    def test_getting_a_multiquestion_as_a_section_preserves_value_of_context_attribute(self):
         multiquestion_data = {
             "id": "example",
             "slug": "example",

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,41 @@
+import pytest
+
+from dmcontent.messages import ContentMessage
+from dmcontent.utils import TemplateField
+from dmcontent import ContentTemplateError
+
+
+class TestContentMessage(object):
+    def test_content_message_field(self):
+        message = ContentMessage({'name': "Name"})
+
+        assert message.name == 'Name'
+
+    def test_content_message_template_field(self):
+        message = ContentMessage({'name': TemplateField("Name")})
+
+        assert message.name == 'Name'
+
+    def test_content_message_template_field_with_context(self):
+        message = ContentMessage({'name': TemplateField("Field {{ name }}")})
+
+        with pytest.raises(ContentTemplateError):
+            assert message.name
+
+        assert message.filter({'name': 'one'}).name == 'Field one'
+
+    def test_content_message_dict_field_returns_content_message(self):
+        message = ContentMessage({'nested': {'name': TemplateField('Name')}})
+
+        assert isinstance(message.nested, ContentMessage)
+        assert message.nested.name == 'Name'
+
+    def test_content_message_list_field_returns_rendered_fields(self):
+        message = ContentMessage({'nested': [TemplateField('Name'), TemplateField('{{ name }}')]})
+
+        assert message.filter({'name': 'Other'}).nested == ['Name', 'Other']
+
+    def test_nested_content_message_preserves_context(self):
+        message = ContentMessage({'nested': {'name': TemplateField('Nested {{ name }}')}})
+
+        assert message.filter({'name': "message"}).nested.name == 'Nested message'

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -11,6 +11,27 @@ class TestContentMessage(object):
 
         assert message.name == 'Name'
 
+    def test_get_missing_field(self):
+        message = ContentMessage({})
+
+        assert message.get('key', 'default') == 'default'
+
+    def test_message_eq(self):
+        message = ContentMessage({"name": "value"})
+
+        assert message == ContentMessage({"name": "value"})
+        assert not (message == {"name": "value"})
+
+    def test_message_get_item(self):
+        message = ContentMessage({"name": "value"})
+
+        assert message['name'] == 'value'
+
+    def test_message_repr(self):
+        message = ContentMessage({"name": "value"})
+
+        assert message.__repr__()
+
     def test_content_message_template_field(self):
         message = ContentMessage({'name': TemplateField("Name")})
 

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -253,7 +253,6 @@ class TestMultiquestion(QuestionTest):
         assert question.get_question('example2').question == "Question one"
 
 
-
 class TestCheckboxes(QuestionTest):
     def question(self, **kwargs):
         data = {

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -37,6 +37,31 @@ class QuestionTest(object):
         assert 'data=' in repr(self.question())
 
 
+class TestFilterQuestion(object):
+
+    def question(self, **kwargs):
+        data = {
+            "id": "example",
+            "type": "text"
+        }
+        data.update(kwargs)
+
+        return ContentQuestion(data)
+
+    def test_question_filter_without_dependencies(self):
+        question = self.question()
+        assert question.filter({}) is not None
+        assert question.filter({}) is not question
+
+    def test_question_filter_with_dependencies_that_match(self):
+        question = self.question(depends=[{"on": "lot", "being": ["lot-1"]}])
+        assert question.filter({"lot": "lot-1"}) is not None
+        assert question.filter({"lot": "lot-1"}) is not question
+
+    def test_question_filter_with_dependencies_that_are_not_matched(self):
+        question = self.question(depends=[{"on": "lot", "being": ["lot-1"]}])
+        assert question.filter({"lot": "lot-2"}) is None
+
 class TestText(QuestionTest):
     def question(self, **kwargs):
         data = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from dmcontent.errors import ContentTemplateError
+from dmcontent.utils import TemplateField
+
+
+class TestTemplateField(object):
+    def test_empty_template(self):
+        field = TemplateField('')
+        assert field.render() == ''
+
+    def test_template_without_template_tags(self):
+        field = TemplateField('simple template')
+        assert field.render() == 'simple template'
+
+    def test_unicode_characters_in_template(self):
+        field = TemplateField(u'\u00a3simple template')
+        assert field.render() == u'£simple template'
+
+    def test_html_tags_in_template_are_not_escaped(self):
+        field = TemplateField(u'<span>simple&nbsp;template</span>')
+        assert field.render() == u'<span>simple&nbsp;template</span>'
+
+    def test_template_with_context(self):
+        field = TemplateField(u'template {{ name }}')
+        assert field.render({'name': 'context'}) == u'template context'
+
+    def test_template_with_conditions(self):
+        field = TemplateField(u"{% if name == 'context' %}template {{ name }}{% endif %}")
+        assert field.render({'name': 'context'}) == u'template context'
+
+    def test_undefined_template_variables_raise_an_error(self):
+        field = TemplateField(u'template {{ name }}')
+
+        with pytest.raises(ContentTemplateError):
+            field.render()
+
+    def test_unused_template_variables_are_ignored(self):
+        field = TemplateField(u'template {{ name }}')
+
+        assert field.render({'name': 'context', 'lot': 'lot'}) == u'template context'
+
+    def test_unicode_characters_in_template_context(self):
+        field = TemplateField(u'template {{ name }}')
+        assert field.render({'name': u'\u00a3context'}) == u'template £context'
+
+    def test_html_tags_in_template_context_are_escaped(self):
+        field = TemplateField(u'template {{ name }}')
+        assert field.render(
+            {'name': '<span>context&nbsp;</span>'}
+        ) == u'template &lt;span&gt;context&amp;nbsp;&lt;/span&gt;'
+
+    def test_template_tags_in_template_context_are_not_evaluated(self):
+        field = TemplateField(u'template {{ name }}')
+        assert field.render(
+            {'name': '{{ other }}'}
+        ) == u'template {{ other }}'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+from jinja2 import Markup
 
 from dmcontent.errors import ContentTemplateError
 from dmcontent.utils import TemplateField
@@ -10,6 +11,10 @@ class TestTemplateField(object):
     def test_empty_template(self):
         field = TemplateField('')
         assert field.render() == ''
+
+    def test_template_renders_as_markup(self):
+        field = TemplateField('simple template')
+        assert isinstance(field.render(), Markup)
 
     def test_template_without_template_tags(self):
         field = TemplateField('simple template')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,3 +57,23 @@ class TestTemplateField(object):
         assert field.render(
             {'name': '{{ other }}'}
         ) == u'template {{ other }}'
+
+    def test_fields_are_processed_with_markdown(self):
+        field = TemplateField(u'# Title\n* Hello\n* Markdown')
+
+        assert field.render() == '<h1>Title</h1>\n<ul>\n<li>Hello</li>\n<li>Markdown</li>\n</ul>'
+
+    def test_simple_strings_are_not_wrapped_in_paragraph_tags(self):
+        field = TemplateField(u'Title string')
+
+        assert field.render() == 'Title string'
+
+    def test_jinja_markdown_errors_raise_an_exception(self):
+        with pytest.raises(ContentTemplateError):
+            TemplateField(u'Title:\nnumber {{ number*2*5 }}')
+
+    def test_markdown_characters_in_jinja_tags(self):
+        assert TemplateField(u'Title:\nnumber {{ number._value }}')
+        assert TemplateField(u'Title:\nnumber {{ number["value"] }}')
+        assert TemplateField(u'Title:\nnumber {{ number|join(".") }}')
+        assert TemplateField(u"Title:\n{% if name == 'context' %}template {{ name }}{% endif %}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,13 @@ from dmcontent.utils import TemplateField
 
 
 class TestTemplateField(object):
+    def test_template_field_eq(self):
+        assert TemplateField(u'string') == TemplateField(u'string')
+        assert not (TemplateField(u'string') == 'string')
+
+    def test_template_field_repr(self):
+        assert TemplateField(u'string').__repr__()
+
     def test_empty_template(self):
         field = TemplateField('')
         assert field.render() == ''


### PR DESCRIPTION
**Note:**
⚠️  This needs to come in at the same time as version 4.x.x of the frameworks repo. [PR here](https://github.com/alphagov/digitalmarketplace-frameworks/pull/326) ⚠️ 

***


### What changed

Before, all values in YAML files were stored as strings and then printed out
directly by jinja in the frontend apps.  Now, we're creating [TemplateField](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/utils.py#L8)s
for specific attibutes of questions and sections.  TemplateFields are wrappers
around jinja [Templates](http://jinja.pocoo.org/docs/dev/api/#jinja2.Template) that are passed an initial string and then are rendered
with a context.
The result of all this is that we can pass variables to our content which
come from briefs or lots or service data or whatever else, either to be
printed as part of the content or evaluated as part of some logic operation.

These are the fields that are turned into TemplateFields when the YAML files are loaded:

| ContentSection                    | Question                                           |
|-----------------------------------|----------------------------------------------------|
| [`name`, `description`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/content_loader.py#L123) | [`question`, `name`, `question_advice`, `hint`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/questions.py#L10) |

[ContentTemplateError](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/errors.py#L8)s are raised if a TemplateField is accessed (ie, [rendered](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/content_loader.py#L166-L167)) without
the variables it needs.  Although we don't have a way to verify that every templated
field gets all of the variables it expects in every case (we would only know
this for sure in the view logic in the frontend apps), we have tests to make sure
HTML and jinja logic is escaped before it is presented to the user.

Nothing that is currently working will break with this update, so the example
below shows how a previously static field can now be given a variable.

### Example app change

#### Old
```yml
# digitalmarketplace-frameworks/frameworks/digital-outcomes-and-specialists/manifests/edit_brief_response.yml
name: Apply for this opportunity
```

```python
# digitalmarketplace-supplier-frontend/app/main/views/briefs.py
def create_brief_response(brief_id):
  section = manifest.get_section('apply').filter({})
  return render_template(section=section)
```

```jinja
<!-- digitalmarketplace-supplier-frontend/app/templates/briefs/brief_response.html -->
<h1>{{ section.name }}</h1>
```

```html
<!-- Output -->
<h1>Apply for this opportunity</h1>
```

#### New
```yml
# digitalmarketplace-frameworks/frameworks/digital-outcomes-and-specialists/manifests/edit_brief_response.yml
name: Apply for ‘{{ brief.title }}’
```

```python
# digitalmarketplace-supplier-frontend/app/main/views/briefs.py
def create_brief_response(brief_id):
  section = manifest.get_section('apply').filter({'brief': brief})
  return render_template(section=section)
```

```jinja
<!-- digitalmarketplace-supplier-frontend/app/templates/briefs/brief_response.html -->
<h1>{{ section.name }}</h1>
```

```html
<!-- Output -->
<h1>Apply for ‘Home Office IPT Programme Caseworking and DPM Delivery Partner’</h1>
```

***

(We have also replaced `yml.load` with `yml.safe_load` after reading [the dire warning in the PyYAML documentation](http://pyyaml.org/wiki/PyYAMLDocumentation#LoadingYAML))

***

[Relevant story on Pivotal](https://www.pivotaltracker.com/story/show/131733667)