### PR TITLE
Add support for nested lists/dicts in ContentMessage list fields

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/dmcontent/messages.py
+++ b/dmcontent/messages.py
@@ -29,12 +29,15 @@ class ContentMessage(object):
         except KeyError:
             raise AttributeError(key)
 
+        return self._render(field)
+
+    def _render(self, field):
         if isinstance(field, TemplateField):
             return field.render(self._context)
         elif isinstance(field, dict):
             return ContentMessage(field, _context=self._context)
         elif isinstance(field, list):
-            return [i.render(self._context) for i in field]
+            return [self._render(i) for i in field]
         else:
             return field
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -56,6 +56,15 @@ class TestContentMessage(object):
 
         assert message.filter({'name': 'Other'}).nested == ['Name', 'Other']
 
+    def test_content_message_list_field_returns_content_messages(self):
+        message = ContentMessage({'nested': [{'name': 'Name'}, {'name': TemplateField('{{ name }}')}]})
+
+        assert message.filter({'name': 'Other'}).nested == [
+            ContentMessage({'name': 'Name'}, {'name': 'Other'}),
+            ContentMessage({'name': TemplateField('{{ name }}')}, {'name': 'Other'})
+        ]
+        assert message.filter({'name': 'Other'}).nested[1].name == 'Other'
+
     def test_nested_content_message_preserves_context(self):
         message = ContentMessage({'nested': {'name': TemplateField('Nested {{ name }}')}})
 


### PR DESCRIPTION
Content variation template uses a list of dictionaries for rendering framework agreement changes so we need to support arbitrary nesting of structures in ContentMessage.

The logic remains mostly the same:
* render simple fields right away
* wrap dictionaries with `ContentMessage`
* render/wrap all items inside a list individually