### PR TITLE
Add DynamicList question

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.1.0'
+__version__ = '2.2.0'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -240,8 +240,7 @@ class DynamicList(Multiquestion):
 
     def __init__(self, data, *args, **kwargs):
         super(DynamicList, self).__init__(data, *args, **kwargs)
-
-        self.type = 'multiquestion'
+        self.type = 'multiquestion' # same UI components as Multiquestion
 
     def filter(self, context):
         dynamic_list = super(Multiquestion, self).filter(context)

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -287,9 +287,13 @@ class DynamicList(Multiquestion):
         q_data = {}
         for question in self.questions:
             q_data.update(question.get_data(form_data))
-        answers = sorted([(int(k.split('-')[1]), k.split('-')[0], v) for k, v in q_data.items()])
-        if not len(answers):
+
+        if not q_data:
             return {self.id: []}
+        elif self._context is None:
+            raise ValueError("DynamicList question requires correct .filter context to parse form data")
+
+        answers = sorted([(int(k.split('-')[1]), k.split('-')[0], v) for k, v in q_data.items()])
 
         questions_data = [{} for i in range(1 + (answers[-1][0]))]
         for index, question, value in answers:

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -240,7 +240,7 @@ class DynamicList(Multiquestion):
 
     def __init__(self, data, *args, **kwargs):
         super(DynamicList, self).__init__(data, *args, **kwargs)
-        self.type = 'multiquestion' # same UI components as Multiquestion
+        self.type = 'multiquestion'  # same UI components as Multiquestion
 
     def filter(self, context):
         dynamic_list = super(Multiquestion, self).filter(context)

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -299,9 +299,32 @@ class DynamicList(Multiquestion):
 
         return {self.id: questions_data}
 
+    def get_error_messages(self, errors):
+        if self.id not in errors:
+            return {}
+
+        question_errors = {}
+        for error in errors[self.id]:
+            if 'field' in error:
+                input_name = '{}-{}'.format(error['field'], error['index'])
+            else:
+                input_name = self.id
+
+            question = self.get_question(input_name)
+            question_errors[input_name] = {
+                'input_name': input_name,
+                'question': question.label,
+                'message':  question.get_error_message(error['error']),
+            }
+
+        return question_errors
+
     @property
     def form_fields(self):
         return [self.id]
+
+    def summary(self, service_data):
+        return DynamicListSummary(self, service_data)
 
     def _make_dynamic_question(self, question, item, index):
         question = question.filter({'item': item})
@@ -452,6 +475,10 @@ class MultiquestionSummary(QuestionSummary, Multiquestion):
             return False
 
         return any(question.answer_required for question in self.questions)
+
+
+class DynamicListSummary(MultiquestionSummary, DynamicList):
+    pass
 
 
 class PricingSummary(QuestionSummary, Pricing):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -9,16 +9,15 @@ from dmcontent import ContentTemplateError
 
 
 class QuestionTest(object):
-    _default_context = {}
+    default_context = {}
 
-    def _get_context(self, context={}):
+    def context(self, context=None):
         """
         Update the provided context (if any) with the default context for this test.
-        Override _default_context when testing question types that must have additional
+        Override default_context when testing question types that must have additional
         context injected in the 'filter' call.
         """
-        context.update(self._default_context)
-        return context
+        return dict(context or {}, **self.default_context)
 
     def test_get_question(self):
         question = self.question()
@@ -51,17 +50,17 @@ class QuestionTest(object):
 
     def test_question_filter_without_dependencies(self):
         question = self.question()
-        assert question.filter(self._get_context()) is not None
-        assert question.filter(self._get_context()) is not question
+        assert question.filter(self.context()) is not None
+        assert question.filter(self.context()) is not question
 
     def test_question_filter_with_dependencies_that_match(self):
         question = self.question(depends=[{"on": "lot", "being": ["lot-1"]}])
-        assert question.filter(self._get_context({"lot": "lot-1"})) is not None
-        assert question.filter(self._get_context({"lot": "lot-1"})) is not question
+        assert question.filter(self.context({"lot": "lot-1"})) is not None
+        assert question.filter(self.context({"lot": "lot-1"})) is not question
 
     def test_question_filter_with_dependencies_that_are_not_matched(self):
         question = self.question(depends=[{"on": "lot", "being": ["lot-1"]}])
-        assert question.filter(self._get_context({"lot": "lot-2"})) is None
+        assert question.filter(self.context({"lot": "lot-2"})) is None
 
     def test_question_without_template_tags_are_unchanged(self):
         question = self.question(
@@ -69,7 +68,7 @@ class QuestionTest(object):
             question=TemplateField("Question"),
             hint=TemplateField("Hint"),
             question_advice=TemplateField("Advice")
-        ).filter(self._get_context())
+        ).filter(self.context())
 
         assert question.name == "Name"
         assert question.question == "Question"
@@ -82,7 +81,7 @@ class QuestionTest(object):
             question=TemplateField("Question {{ question }}"),
             hint=TemplateField("Hint {{ hint }}"),
             question_advice=TemplateField("Advice {{ advice }}")
-        ).filter(self._get_context({
+        ).filter(self.context({
             "name": "zero",
             "question": "one",
             "hint": "two",
@@ -257,7 +256,7 @@ class TestMultiquestion(QuestionTest):
                 "type": "text",
                 "question": TemplateField("Question {{ name }}")
             }]
-        ).filter(self._get_context({
+        ).filter(self.context({
             "name": "one",
         }))
 
@@ -265,20 +264,24 @@ class TestMultiquestion(QuestionTest):
 
 
 class TestDynamicListQuestion(QuestionTest):
-    _default_context = {'someplace': {'somequestion': ['First Need', 'Second Need', 'Third Need'], }}
+    default_context = {'context': {'field': ['First Need', 'Second Need', 'Third Need']}}
 
     def question(self, **kwargs):
         data = {
             "id": "example",
             "type": "dynamic_list",
-            "dynamic_field": "someplace.somequestion",
+            "question": "Dynamic list",
+            "dynamic_field": "context.field",
             "questions": [
                 {
                     "id": "example2",
+                    "question": TemplateField("{{ item }}-2"),
                     "type": "text",
+                    "followup": "example3"
                 },
                 {
                     "id": "example3",
+                    "question": TemplateField("{{ item }}-3"),
                     "type": "number",
                 }
             ]
@@ -298,14 +301,12 @@ class TestDynamicListQuestion(QuestionTest):
 
     def test_get_data_malformed_submission_no_context_applied(self):
         question = self.question()  # no context applied
-        # TODO this one currently throws - should either be a better exception or should behave as below?
-        assert question.get_data(
-            {'example2': 'value2', 'example3': 'value3'}
-        ) == {'example': []}
+        with pytest.raises(ValueError):
+            question.get_data({'example2': 'value2', 'example3': 'value3'})
 
     def test_get_data(self):
         # must "filter" to apply context as without it, borkedness
-        question = self.question().filter(self._get_context())
+        question = self.question().filter(self.context())
         assert question.get_data(
             {'example2-0': 'First Need example2 response', 'example2-2': 'Third Need example2 response'}
         ) == {
@@ -320,6 +321,34 @@ class TestDynamicListQuestion(QuestionTest):
                     'example2': 'Third Need example2 response'
                 }
             ]
+        }
+
+    def test_get_error_messages_unknown_key(self):
+        question = self.question().filter(self.context())
+        assert question.get_error_messages({'example1': 'answer_required'}) == {}
+
+    def test_get_error_messages(self):
+        question = self.question().filter(self.context())
+        assert question.get_error_messages({'example': [
+            {'field': 'example2', 'index': 0, 'error': 'answer_required'},
+            {'field': 'example3', 'index': 0, 'error': 'answer_required'},
+            {'index': 1, 'error': 'answer_required'}
+        ]}) == {
+            'example': {
+                'input_name': 'example',
+                'message': 'There was a problem with the answer to this question',
+                'question': 'Dynamic list'
+            },
+            'example2-0': {
+                'input_name': 'example2-0',
+                'message': 'There was a problem with the answer to this question',
+                'question': u'First Need-2'
+            },
+            'example3-0': {
+                'input_name': 'example3-0',
+                'message': 'There was a problem with the answer to this question',
+                'question': u'First Need-3'
+            }
         }
 
 
@@ -608,3 +637,32 @@ class TestMultiquestionSummary(QuestionSummaryTest):
     def test_is_empty_partial(self):
         question = self.question().summary({'example2': 'value2'})
         assert not question.is_empty
+
+
+class TestDynamicListSummary(QuestionSummaryTest):
+    def question(self, **kwargs):
+        data = {
+            "id": "example",
+            "type": "dynamic_list",
+            "question": "Dynamic list",
+            "dynamic_field": "context.field",
+            "questions": [
+                {
+                    "id": "example2",
+                    "question": TemplateField("{{ item }}-2"),
+                    "type": "text",
+                },
+                {
+                    "id": "example3",
+                    "question": TemplateField("{{ item }}-3"),
+                    "type": "number",
+                }
+            ]
+        }
+        data.update(kwargs)
+
+        return ContentQuestion(data).filter({'context': {'field': ['First Need', 'Second Need', 'Third Need']}})
+
+    def test_value_missing(self):
+        question = self.question().summary({})
+        assert question.value == []


### PR DESCRIPTION
## Document changes to content loader

In order to do nice-to-have questions with optional evidence
questions, we've created a new DynamicList question type.

1. `DynamicList` questions

`DynamicList` mostly works like a multiquestion, with a few key
differences:

 - `.filter()` method merges its original templated questions with
   brief data to generate new questions.  This means we can
   leave a question's "question" field as "{{ item }}" and then
   pass a string into it from a brief just before rendering it.
 - `.filter()` method also rewrites question "id"s and "followup"s
   with trailing index numbers.
   eg `id: "yesno"` becomes `id: "yesno-0"` or whatever
 - `.get_data()` method transforms data that comes back from
   the form into something the API will understand, sanitizing
   values and grouping related questions together.
   eg `{"yesno-1": "true", "evidence-1": "yes"}` will become
   `{"dynamicListKey": [{}, {"yesno": True, "evidence": "yes}]}`
-  `.get_error_messages()` for a DynamicList looks for errors
   returned from the API that contain a "field".  The field is the
   name of the key that failed: it tells us whether the user didn't    answer the main question or whether they didn't answer the
   followup.  This means we can put the validation message in the
   right place.

2. tech debt type stuff

 - DynamicList questions only work with one followup.
   eg we can have `followup: "evidence"` but we can't have it
   require two or three other questions.
 - We haven't covered any of the stranger questions when making
   our DynamicList.  That is, DynamicLists can easily contain
   text, boolean, or large_textbox fields, but if you give them
   pricing or assurance questions, the whole thing will break.
 - `.get_question_as_section()` method was a quick hack that
   served us pretty well, but it's starting to break as we rely
   on it more and more.  Currently, it works fine for displaying
   data, but not for returning the processed form data to the
   rendered HTML form after a validation error.
 - `macros/toolkit_forms.html` multiquestion macro (in the
   supplier frontend) only supports nested questions where
   `type: text`
 - No way to unformat data 😫. After getting data back in the
   view (`request.form`), we call `.get_data()` on it to
   turn it into something the API will understand, but if
   we get a validation error, we aren't able to pass the
   data back to the form to repopulate our old values.
   It's a bit strange because the error messages show up
   where we expect them to, just not the old values.

**Also, there are no tests for our new stuff.**