### PR TITLE
Add `section.get_next_question_id` method

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -214,6 +214,24 @@ class ContentSection(object):
             question_id for question in self.questions for question_id in question.get_question_ids(type)
         ]
 
+    def get_next_question_id(self, question_id=None):
+        """Return the next question id
+
+        If no question_id provided will return the first question
+        If last question_id provided will return `None`
+        Will ignore any questions that are questions attributed to a multiquestion
+        """
+        return_next_questions_id = question_id is None
+
+        for question in self.questions:
+            if return_next_questions_id:
+                return question.id
+
+            if question.id == question_id:
+                return_next_questions_id = True
+
+        return None
+
     def get_data(self, form_data):
         """Extract data for a section from a submitted form
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -708,6 +708,48 @@ class TestContentSection(object):
         })
         assert section.get_question_ids() == ['q2', 'q3']
 
+    def test_get_next_question_id(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "first_question",
+                "question": "Boolean question",
+                "type": "boolean",
+            }, {
+                "id": "second_question",
+                "question": "Multi question",
+                "type": "multiquestion",
+                "questions": [
+                    {
+                        "id": "multiquestion-1",
+                        "type": "text"
+                    },
+                    {
+                        "id": "multiquestion-2",
+                        "type": "text"
+                    }
+                ]
+            }, {
+                "id": "third_question",
+                "question": "Text question",
+                "type": "text",
+            }]
+        })
+
+        assert section.get_next_question_id() == "first_question"
+        assert section.get_next_question_id("first_question") == "second_question"
+        assert section.get_next_question_id("second_question") == "third_question"
+        assert section.get_next_question_id("third_question") is None
+
+    def test_get_next_question_id_for_section_with_no_questions_returns_none(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": []
+        })
+        assert section.get_next_question_id() is None
+
     def test_get_question_as_section(self):
         section = ContentSection.create({
             "slug": "first_section",


### PR DESCRIPTION
Will be used so we can iterate through questions, one per page, for the new brief response flow. Similar to the `manifest.get_next_section_id` method.

- Will return the id of the next question
- If no question_id provided will return the first question
- If last question_id provided will return `None`
- Will ignore any questions that are questions attributed to a multiquestion