### PR TITLE
Add `unformat_data` method to `Question` and `DynamicListQuestion`

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.3.0'
+__version__ = '2.4.0'

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -323,6 +323,26 @@ class TestDynamicListQuestion(QuestionTest):
             ]
         }
 
+    def test_unformat_data(self):
+        # must "filter" to apply context as without it, borkedness
+        question = self.question().filter(self.context())
+        data = {
+            "example": [
+                {'example2': 'First Need example 2 response', 'example3': 'my follow up'},
+                {},
+                {'example2': 'Third Need example2 response'}
+            ],
+            "nonDynamicKey": 'data'
+        }
+        expected = {
+            "example2-0": 'First Need example 2 response',
+            "example3-0": 'my follow up',
+            "example2-2": 'Third Need example2 response',
+            "nonDynamicKey": 'data'
+        }
+
+        assert question.unformat_data(data) == expected
+
     def test_get_error_messages_unknown_key(self):
         question = self.question().filter(self.context())
         assert question.get_error_messages({'example1': 'answer_required'}) == {}


### PR DESCRIPTION
This method unpacks service data to be used in a form. Dynamic lists data is stored differently to that passed to a form and therefore requires manipulation from one key into several top level keys.

So we can call `unformat_data` from any question without having to worry about if it is a dynamic list or not I have also added a method to the parent `Question` class that will simply return the data passed in.