### PR TITLE
Return ordered dynamic list question errors

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.4.0'
+__version__ = '2.4.1'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -350,7 +350,12 @@ class DynamicList(Multiquestion):
         if self.id not in errors:
             return {}
 
-        question_errors = {}
+        # Assumes errors being passed in are ordered by 'index' key e.g.
+        # {'example': [
+        #     {'index': 0, 'error': 'answer_required'}
+        #     {'index': 1, 'error': 'answer_required'}
+        # ]}
+        question_errors = OrderedDict()
         for error in errors[self.id]:
             if 'field' in error:
                 input_name = '{}-{}'.format(error['field'], error['index'])

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from collections import OrderedDict
 
 import pytest
 
@@ -349,27 +350,30 @@ class TestDynamicListQuestion(QuestionTest):
 
     def test_get_error_messages(self):
         question = self.question().filter(self.context())
-        assert question.get_error_messages({'example': [
+        ordered_dict = question.get_error_messages({'example': [
             {'field': 'example2', 'index': 0, 'error': 'answer_required'},
             {'field': 'example3', 'index': 0, 'error': 'answer_required'},
             {'index': 1, 'error': 'answer_required'}
-        ]}) == {
-            'example': {
-                'input_name': 'example',
-                'message': 'There was a problem with the answer to this question',
-                'question': 'Dynamic list'
-            },
-            'example2-0': {
+        ]})
+
+        errors = list(ordered_dict.items())
+        assert errors == [
+            ('example2-0', {
                 'input_name': 'example2-0',
                 'message': 'There was a problem with the answer to this question',
                 'question': u'First Need-2'
-            },
-            'example3-0': {
+            }),
+            ('example3-0', {
                 'input_name': 'example3-0',
                 'message': 'There was a problem with the answer to this question',
                 'question': u'First Need-3'
-            }
-        }
+            }),
+            ('example', {
+                'input_name': 'example',
+                'message': 'There was a problem with the answer to this question',
+                'question': 'Dynamic list'
+            })
+        ]
 
 
 class TestCheckboxes(QuestionTest):


### PR DESCRIPTION
We want our question errors ordered by index. JSON schema errors on a list of objects should give us back our errors ordered by index. These errors are passed from the API to the content loader. Based on this assumption, we just need to maintain this order using an OrderedDict.