### PR TITLE
Remove followup answers for False answer to dynamic list questions

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.4.2'
+__version__ = '2.4.3'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -270,8 +270,10 @@ class DynamicList(Multiquestion):
             "respondToEmailAddress": "paul@paul.paul",
             "yesno-0": "true",
             "yesno-1": "false",
+            "yesno-2": "false",
             "evidence-0": "Yes, I did.",
             "evidence-1": ""
+            "evidence-2": "to be removed"
         }
 
         # OUT
@@ -280,6 +282,9 @@ class DynamicList(Multiquestion):
             [{
                 "yesno": True,
                 "evidence": "Yes, I did."
+            },
+            {
+                "yesno": False
             },
             {
                 "yesno": False
@@ -295,6 +300,12 @@ class DynamicList(Multiquestion):
             return {self.id: []}
         elif self._context is None:
             raise ValueError("DynamicList question requires correct .filter context to parse form data")
+
+        # Remove any follow up answer if the question that requires followup has been answered `False`
+        for question in self.questions:
+            if question.get('followup'):
+                if q_data.get(question.id) is False:
+                    q_data.pop(question.followup, None)
 
         answers = sorted([(int(k.split('-')[1]), k.split('-')[0], v) for k, v in q_data.items()])
 

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -265,7 +265,7 @@ class TestMultiquestion(QuestionTest):
 
 
 class TestDynamicListQuestion(QuestionTest):
-    default_context = {'context': {'field': ['First Need', 'Second Need', 'Third Need']}}
+    default_context = {'context': {'field': ['First Need', 'Second Need', 'Third Need', 'Fourth need']}}
 
     def question(self, **kwargs):
         data = {
@@ -308,8 +308,13 @@ class TestDynamicListQuestion(QuestionTest):
     def test_get_data(self):
         # must "filter" to apply context as without it, borkedness
         question = self.question().filter(self.context())
-        assert question.get_data(
-            {'yesno-0': True, 'evidence-0': 'some evidence', 'yesno-2': False}
+        assert question.get_data({
+            'yesno-0': True,
+            'evidence-0': 'some evidence',
+            'yesno-2': False,
+            'yesno-3': False,
+            'evidence-3': 'should be removed'
+        }
         ) == {
             'example': [
                 {
@@ -318,6 +323,9 @@ class TestDynamicListQuestion(QuestionTest):
                 },
                 {
                     # missing second example (index 1) on purpose
+                },
+                {
+                    'yesno': False
                 },
                 {
                     'yesno': False
@@ -332,7 +340,8 @@ class TestDynamicListQuestion(QuestionTest):
             "example": [
                 {'yesno': True, 'evidence': 'my evidence'},
                 {},
-                {'yesno': False}
+                {'yesno': False},
+                {}
             ],
             "nonDynamicKey": 'data'
         }


### PR DESCRIPTION
For [this pivotal story](https://www.pivotaltracker.com/story/show/133440815)

Our form data may include followup answers which are non empty (if the user says yes to the question, adds followup answer and then changes their mind and says no to the original question). This would mean that `False` would be sent with the follow up answer in the form data. We wish to strip out the follow up answer in this case when using `get_data` as it is redundant information.