### PR TITLE
Add `get_previous_question_id` to `ContentSection` class

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.4.3'
+__version__ = '2.5.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -232,6 +232,23 @@ class ContentSection(object):
 
         return None
 
+    def get_previous_question_id(self, question_id):
+        """Return the previous question id
+
+        If first question_id provided will return `None`
+        If question id does not exist in self.questions will return `None`
+        Will ignore any questions that are questions attributed to a multiquestion
+        """
+        return_next_questions_id = False
+        for question in reversed(self.questions):
+            if return_next_questions_id:
+                return question.id
+
+            if question.id == question_id:
+                return_next_questions_id = True
+
+        return None
+
     def get_data(self, form_data):
         """Extract data for a section from a submitted form
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -750,6 +750,49 @@ class TestContentSection(object):
         })
         assert section.get_next_question_id() is None
 
+    def test_get_previous_question_id(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": [{
+                "id": "first_question",
+                "question": "Boolean question",
+                "type": "boolean",
+            }, {
+                "id": "second_question",
+                "question": "Multi question",
+                "type": "multiquestion",
+                "questions": [
+                    {
+                        "id": "multiquestion-1",
+                        "type": "text"
+                    },
+                    {
+                        "id": "multiquestion-2",
+                        "type": "text"
+                    }
+                ]
+            }, {
+                "id": "third_question",
+                "question": "Text question",
+                "type": "text",
+            }]
+        })
+
+        assert section.get_previous_question_id("first_question") is None
+        assert section.get_previous_question_id("second_question") == "first_question"
+        assert section.get_previous_question_id("third_question") == "second_question"
+        assert section.get_previous_question_id("does_not_exist") is None
+        assert section.get_previous_question_id(None) is None
+
+    def test_get_previous_question_id_for_section_with_no_questions_returns_none(self):
+        section = ContentSection.create({
+            "slug": "first_section",
+            "name": "First section",
+            "questions": []
+        })
+        assert section.get_previous_question_id(None) is None
+
     def test_get_question_as_section(self):
         section = ContentSection.create({
             "slug": "first_section",


### PR DESCRIPTION
Essentially the opposite of `get_next_question_id` apart from the `question_id` argument is not optional as we assume no need to get the last question. Note, if this need does arise then this functionality can easily be added.