### PR TITLE
NO-TICKET-specify-packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.4"
 install:
   - pip install -r requirements_for_test.txt
-  - pip install -e .
 script:
   - PYTEST_ARGS='--cov=dmcontent --cov-report=term-missing' make test
 after_success:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
-inflection==0.3.1
-PyYAML==3.11
-Werkzeug==0.11.9
-six==1.10.0
-Jinja2==2.8
-Markdown==2.6.7
+-e .

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 import re
 import ast
-import pip.download
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 
@@ -10,10 +8,6 @@ _version_re = re.compile(r'__version__\s+=\s+(.*)')
 with open('dmcontent/__init__.py', 'rb') as f:
     version = str(ast.literal_eval(_version_re.search(
         f.read().decode('utf-8')).group(1)))
-
-requirements = list(parse_requirements('requirements.txt', session=pip.download.PipSession()))
-
-install_requires = [str(r.req) for r in requirements]
 
 setup(
     name='digitalmarketplace-content-loader',
@@ -25,5 +19,12 @@ setup(
     long_description=__doc__,
     packages=find_packages(),
     include_package_data=True,
-    install_requires=install_requires
+    install_requires=[
+        'Jinja2==2.8',
+        'Markdown==2.6.7',
+        'PyYAML==3.11',
+        'Werkzeug==0.11.9',
+        'inflection==0.3.1',
+        'six==1.10.0'
+    ]
 )


### PR DESCRIPTION
#### Remove `__init__.py` which are causing tests to be installed as a module

* Remove `tests/*__init__.py` files to avoid tests being added by `find_packages` in `setup.py`.
* Add dependencies to `setup.py`

Explained in depth here:

https://docs.google.com/a/digital.cabinet-office.gov.uk/document/d/1cQFNx4WEvI-IGZ1g9K8JtZfeplrEmoJbtBOOpaJSEdQ