### PR TITLE
[#138702601]ContentSection: add prefill flag

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.6.0'
+__version__ = '2.7.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -131,6 +131,7 @@ class ContentSection(object):
             return ContentSection(
                 slug=section['slug'],
                 name=section['name'],
+                prefill=section.get('prefill'),
                 editable=section.get('editable'),
                 edit_questions=section.get('edit_questions'),
                 questions=[ContentQuestion(question) for question in section['questions']],
@@ -142,6 +143,7 @@ class ContentSection(object):
             self,
             slug,
             name,
+            prefill,
             editable,
             edit_questions,
             questions,
@@ -153,6 +155,7 @@ class ContentSection(object):
         self.id = slug  # TODO deprecated, use `.slug` instead
         self.slug = slug
         self.name = name
+        self.prefill = prefill
         self.editable = editable
         self.edit_questions = edit_questions
         self.questions = questions
@@ -192,6 +195,7 @@ class ContentSection(object):
         return ContentSection(
             slug=question.slug,
             name=question.label,
+            prefill=self.prefill,
             editable=self.edit_questions,
             edit_questions=False,
             questions=question.get('questions', [question]),

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -633,6 +633,7 @@ class TestContentSection(object):
         section = ContentSection.create({
             "slug": "first_section",
             "name": "First section",
+            "prefill": False,
             "questions": [{
                 "id": "q1",
                 "question": "Boolean question",
@@ -844,6 +845,7 @@ class TestContentSection(object):
         section = ContentSection.create({
             "slug": "first_section",
             "name": "First section",
+            "prefill": False,
             "questions": [{
                 "id": "first_question",
                 "slug": "first_question_slug",
@@ -891,6 +893,7 @@ class TestContentSection(object):
     def test_get_multiquestion_as_section(self):
         section = ContentSection.create({
             "slug": "first_section",
+            "prefill": True,
             "edit_questions": True,
             "editable": True,
             "name": "First section",
@@ -916,6 +919,7 @@ class TestContentSection(object):
         question_section = section.get_question_as_section('q0-slug')
         assert question_section.name == "Q0"
         assert question_section.description == "Some description"
+        assert question_section.prefill is True
         assert question_section.editable == section.edit_questions
         assert question_section.get_question_ids() == ['q2', 'q3']
 
@@ -931,6 +935,7 @@ class TestContentSection(object):
         question_section = section.get_question_as_section('q1-slug')
         assert question_section.slug == "q1-slug"
         assert question_section.description == "Some description"
+        assert question_section.prefill is None
         assert question_section.editable == section.edit_questions
         assert question_section.edit_questions is False
 
@@ -1375,6 +1380,7 @@ class TestContentSection(object):
         section = ContentSection.create({
             "slug": "second_section",
             "name": "Second section",
+            "prefill": True,
             "questions": [{
                 "id": "q2",
                 "question": "Second question",
@@ -1658,7 +1664,7 @@ class TestContentLoader(object):
     def manifest1(self):
         return [
             {"name": "section1", "questions": ["question1", "question2"]},
-            {"name": "section2", "slug": "section-2", "questions": ["question3"]}
+            {"name": "section2", "slug": "section-2", "prefill": True, "questions": ["question3"]}
         ]
 
     def question1(self):
@@ -1686,6 +1692,7 @@ class TestContentLoader(object):
                      'name': TemplateField('question2'), 'slug': 'q2', 'id': 'q2'}],
                 'slug': 'section1'},
             {'name': TemplateField('section2'),
+             'prefill': True,
              'questions': [
                  {'depends': [{'being': 'IaaS', 'on': 'lot'}],
                   'name': TemplateField('question3'), 'slug': 'question3', 'id': 'question3'}],
@@ -1746,6 +1753,7 @@ class TestContentLoader(object):
         section = yaml_loader._process_section('framework-slug', 'question-set', {
             "name": "section1",
             "description": "This is the first section",
+            "prefill": False,
             "editable": True,
             "questions": []
         })
@@ -1754,6 +1762,7 @@ class TestContentLoader(object):
             "name": TemplateField("section1"),
             "slug": "section1",
             "description": TemplateField("This is the first section"),
+            "prefill": False,
             "editable": True,
             "questions": []
         }

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -12,6 +12,7 @@ class TestFilterContentSection(object):
             slug='section',
             name=TemplateField('Section'),
             description=TemplateField('just a string'),
+            prefill=True,
             editable=False,
             edit_questions=False,
             questions=[Question({})]
@@ -19,11 +20,13 @@ class TestFilterContentSection(object):
 
         assert section.filter({}).name == 'Section'
         assert section.filter({}).description == 'just a string'
+        assert section.filter({}).prefill is True
 
     def test_question_fields_without_template_tags_are_unchanged(self):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section'),
+            prefill=False,
             editable=False,
             edit_questions=False,
             questions=[Question({'name': 'Question'})]
@@ -35,6 +38,7 @@ class TestFilterContentSection(object):
         section = ContentSection(
             slug='# {{ section }}',
             name=TemplateField('Section'),
+            prefill=True,
             editable=False,
             edit_questions=False,
             questions=[Question({})]
@@ -46,6 +50,7 @@ class TestFilterContentSection(object):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section {{ name }}'),
+            prefill=False,
             editable=False,
             edit_questions=False,
             questions=[Question({})]
@@ -58,6 +63,7 @@ class TestFilterContentSection(object):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section {{ name }}'),
+            prefill=True,
             editable=False,
             edit_questions=False,
             questions=[Question({})]
@@ -69,6 +75,7 @@ class TestFilterContentSection(object):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section {{ name }}'),
+            prefill=True,
             editable=False,
             edit_questions=False,
             questions=[Question({})]
@@ -80,6 +87,7 @@ class TestFilterContentSection(object):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section one'),
+            prefill=False,
             editable=False,
             edit_questions=False,
             questions=[Question({})],
@@ -92,6 +100,7 @@ class TestFilterContentSection(object):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section one'),
+            prefill=False,
             editable=False,
             edit_questions=False,
             questions=[Question({})]
@@ -103,6 +112,7 @@ class TestFilterContentSection(object):
         section = ContentSection(
             slug='section',
             name=TemplateField('{% if True %}Section one{% else %}Section two{% endif %}'),
+            prefill=True,
             editable=False,
             edit_questions=False,
             questions=[Question({})],
@@ -121,6 +131,7 @@ class TestFilterContentSection(object):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section'),
+            prefill=False,
             editable=False,
             edit_questions=False,
             questions=[Question({'name': 'Question'})]
@@ -129,6 +140,8 @@ class TestFilterContentSection(object):
 
         copied_section = section.copy()
         assert copied_section._context == section._context
+        assert copied_section.prefill is False
+        assert copied_section.editable is False
 
     def test_getting_a_multiquestion_as_a_section_preserves_value_of_context_attribute(self):
         multiquestion_data = {
@@ -151,6 +164,7 @@ class TestFilterContentSection(object):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section'),
+            prefill=True,
             editable=False,
             edit_questions=False,
             questions=[Multiquestion(multiquestion_data)]
@@ -165,6 +179,7 @@ class TestFilterContentSection(object):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section one'),
+            prefill=False,
             editable=False,
             edit_questions=False,
             questions=[Question({})],


### PR DESCRIPTION
Story https://www.pivotaltracker.com/story/show/138702601

Really just followed the path of `editable`. Though noted that `editable` handling itself is a bit under-tested.