### PR TITLE
slugification: handle unicode whitespace properly

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.7.0'
+__version__ = '2.7.1'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -574,7 +574,7 @@ def _load_question(question, directory):
 
 def _make_slug(name):
     return inflection.underscore(
-        re.sub(r"[\s&?]", "_", name).strip("_")
+        re.sub(r"[\s&?]", "_", name, flags=re.UNICODE).strip("_")
     ).replace('_', '-')
 
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1998,6 +1998,7 @@ class TestContentLoader(object):
     ("The Title", "the-title"),
     ("This\nAnd\tThat ", "this-and-that"),
     ("This&That?", "this-that"),
+    (u"This\u00a0That\u202f", "this-that"),
 ])
 def test_make_slug(title, slug):
     assert _make_slug(title) == slug


### PR DESCRIPTION
This was tripping up on (letting through) nbsp's.