### PR TITLE
Add get_source attribute for the benefit of the CSV downloader.

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.7.1'
+__version__ = '2.8.0'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -181,6 +181,17 @@ class Question(object):
     def __getitem__(self, key):
         return getattr(self, key)
 
+    def get_source(self, key, default=None):
+        try:
+            field = self._data[key]
+        except KeyError:
+            return default
+
+        if isinstance(field, TemplateField):
+            return field.source
+        else:
+            return field
+
     def __repr__(self):
         return '<{0.__class__.__name__}: number={0.number}, data={0._data}>'.format(self)
 

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -94,6 +94,9 @@ class QuestionTest(object):
         assert question.hint == "Hint two"
         assert question.question_advice == "Advice three"
 
+        assert question.get_source('name') == "Name {{ name }}"
+        assert question.get_source('question') == "Question {{ question }}"
+
     def test_question_fields_are_templated_on_access_if_filter_wasnt_called(self):
         question = self.question(
             name=TemplateField("Name {{ name }}"),


### PR DESCRIPTION
 - ticket https://www.pivotaltracker.com/n/projects/904880/stories/138703715
 - requirement is to get 'readable' text, i.e. not rendered into HTML
 - actually, the source can still contain HTML, as much HTML is valid
   markdown, so this is really just a quick-fix