### PR TITLE
Follow up questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 Records breaking changes from major version bumps
 
+## 3.0.0
+
+PR: [#25](https://github.com/alphagov/digitalmarketplace-content-loader/pull/25)
+
+### What changed
+
+Added support for `followup` questions inside multiquestions, radio questions with followups
+and multiple followups for a single question. This requires changing the question YAML file
+syntax for listing followups, so the content loader is modified to support the new format
+and will only work with an updated frameworks repo.
+
+
+### Example change
+
+#### Old
+```yaml
+# digitalmarketplace-frameworks question
+
+id: q1
+type: boolean
+followup: q2
+
+```
+
+#### New
+```yaml
+# digitalmarketplace-frameworks question
+
+id: q1
+type: boolean
+followup:
+  q2:
+    - True
+
+```
+
+
 ## 2.0.0
 
 PR: [#8](https://github.com/alphagov/digitalmarketplace-apiclient/pull/8)

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '2.9.0'
+__version__ = '3.0.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -100,14 +100,14 @@ class ContentManifest(object):
     def get_next_edit_questions_section_id(self, section_id=None):
         return self.get_next_section_id(section_id, only_edit_questions=True)
 
-    def filter(self, context, static=False):
+    def filter(self, context, dynamic=True):
         """Return a new :class:`ContentManifest` filtered by service data
 
         Only includes the questions that should be shown for the provided
         service data. This is calculated by resolving the dependencies
         described by the `depends` section."""
         sections = filter(None, [
-            section.filter(context, static)
+            section.filter(context, dynamic)
             for section in self.sections
         ])
 
@@ -395,12 +395,12 @@ class ContentSection(object):
         for question in self.questions:
             question.inject_brief_questions_into_boolean_list_question(brief)
 
-    def filter(self, context, static=False):
+    def filter(self, context, dynamic=True):
         section = self.copy()
         section._context = context
 
         filtered_questions = list(filter(None, [
-            question.filter(context, static)
+            question.filter(context, dynamic)
             for question in self.questions
         ]))
 

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -100,14 +100,14 @@ class ContentManifest(object):
     def get_next_edit_questions_section_id(self, section_id=None):
         return self.get_next_section_id(section_id, only_edit_questions=True)
 
-    def filter(self, context):
+    def filter(self, context, static=False):
         """Return a new :class:`ContentManifest` filtered by service data
 
         Only includes the questions that should be shown for the provided
         service data. This is calculated by resolving the dependencies
         described by the `depends` section."""
         sections = filter(None, [
-            section.filter(context)
+            section.filter(context, static)
             for section in self.sections
         ])
 
@@ -393,12 +393,12 @@ class ContentSection(object):
         for question in self.questions:
             question.inject_brief_questions_into_boolean_list_question(brief)
 
-    def filter(self, context):
+    def filter(self, context, static=False):
         section = self.copy()
         section._context = context
 
         filtered_questions = list(filter(None, [
-            question.filter(context)
+            question.filter(context, static)
             for question in self.questions
         ]))
 

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -13,7 +13,7 @@ from werkzeug.datastructures import ImmutableMultiDict
 from .errors import ContentNotFoundError, QuestionNotFoundError
 from .questions import Question, ContentQuestion
 from .messages import ContentMessage
-from .utils import TemplateField, template_all
+from .utils import TemplateField, template_all, drop_followups
 
 
 class ContentManifest(object):
@@ -314,6 +314,8 @@ class ContentSection(object):
         section_data = {}
         for question in self.questions:
             section_data.update(question.get_data(form_data))
+
+        section_data = drop_followups(self, section_data)
 
         return section_data
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -330,7 +330,7 @@ class DynamicList(Multiquestion):
         elif self._context is None:
             raise ValueError("DynamicList question requires correct .filter context to parse form data")
 
-        q_data = drop_followups(self, q_data)
+        q_data = drop_followups(self, q_data, nested=True)
 
         answers = sorted([(int(k.split('-')[1]), k.split('-')[0], v) for k, v in q_data.items()])
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 from .converters import convert_to_boolean, convert_to_number
 from .errors import ContentNotFoundError
@@ -135,6 +135,18 @@ class Question(object):
     @property
     def form_fields(self):
         return [self.id]
+
+    @property
+    def values_followup(self):
+        if not self.get('followup'):
+            return {}
+
+        followups = defaultdict(list)
+        for q, values in self.followup.items():
+            for value in values:
+                followups[value].append(q)
+
+        return dict(followups)
 
     @property
     def required_form_fields(self):

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -138,6 +138,13 @@ class Question(object):
 
     @property
     def values_followup(self):
+        """Return a reversed (value->followups) followup mapping
+
+        Form templates need a reversed followup structure: a list of question
+        ids that follow a certain question value.
+
+        """
+
         if not self.get('followup'):
             return {}
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -17,7 +17,7 @@ class Question(object):
     def summary(self, service_data):
         return QuestionSummary(self, service_data)
 
-    def filter(self, context):
+    def filter(self, context, static=False):
         if not self._should_be_shown(context):
             return None
 
@@ -208,13 +208,13 @@ class Multiquestion(Question):
     def summary(self, service_data):
         return MultiquestionSummary(self, service_data)
 
-    def filter(self, context):
-        multi_question = super(Multiquestion, self).filter(context)
+    def filter(self, context, static=False):
+        multi_question = super(Multiquestion, self).filter(context, static)
         if not multi_question:
             return None
 
         multi_question.questions = list(filter(None, [
-            question.filter(context)
+            question.filter(context, static)
             for question in multi_question.questions
         ]))
 
@@ -256,8 +256,11 @@ class DynamicList(Multiquestion):
         super(DynamicList, self).__init__(data, *args, **kwargs)
         self.type = 'multiquestion'  # same UI components as Multiquestion
 
-    def filter(self, context):
-        dynamic_list = super(Multiquestion, self).filter(context)
+    def filter(self, context, static=False):
+        if static:
+            return super(DynamicList, self).filter(context, static)
+
+        dynamic_list = super(Multiquestion, self).filter(context, static)
         if not dynamic_list:
             return None
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -17,7 +17,7 @@ class Question(object):
     def summary(self, service_data):
         return QuestionSummary(self, service_data)
 
-    def filter(self, context, static=False):
+    def filter(self, context, dynamic=True):
         if not self._should_be_shown(context):
             return None
 
@@ -227,13 +227,13 @@ class Multiquestion(Question):
     def summary(self, service_data):
         return MultiquestionSummary(self, service_data)
 
-    def filter(self, context, static=False):
-        multi_question = super(Multiquestion, self).filter(context, static)
+    def filter(self, context, dynamic=True):
+        multi_question = super(Multiquestion, self).filter(context, dynamic)
         if not multi_question:
             return None
 
         multi_question.questions = list(filter(None, [
-            question.filter(context, static)
+            question.filter(context, dynamic)
             for question in multi_question.questions
         ]))
 
@@ -278,11 +278,11 @@ class DynamicList(Multiquestion):
         super(DynamicList, self).__init__(data, *args, **kwargs)
         self.type = 'multiquestion'  # same UI components as Multiquestion
 
-    def filter(self, context, static=False):
-        if static:
-            return super(DynamicList, self).filter(context, static)
+    def filter(self, context, dynamic=True):
+        if not dynamic:
+            return super(DynamicList, self).filter(context, dynamic)
 
-        dynamic_list = super(Multiquestion, self).filter(context, static)
+        dynamic_list = super(Multiquestion, self).filter(context, dynamic)
         if not dynamic_list:
             return None
 

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -40,7 +40,10 @@ class TemplateField(object):
         return (self.source == other.source)
 
     def __repr__(self):
-        return '<{0.__class__.__name__}: "{0.source}">'.format(self)
+        return '<{}: "{}">'.format(
+            self.__class__.__name__,
+            self.source.encode('utf-8')
+        )
 
 
 def template_all(item):

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -75,7 +75,11 @@ def drop_followups(question_or_section, data, nested=False):
 
     for question in question_or_section.questions:
         for followup_id, values in question.get('followup', {}).items():
-            if data.get(question.id) not in values:
+            question_data = data.get(question.id)
+            if not isinstance(question_data, list):
+                question_data = [question_data]
+
+            if not set(question_data) & set(values):
                 for field in question_or_section.get_question(followup_id).form_fields:
                     if nested:
                         data.pop(field, None)

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -58,3 +58,18 @@ def template_all(item):
         return result
     else:
         return item
+
+
+def drop_followups(question_or_section, data):
+    # Remove any follow up answer if the question that requires followup has been answered
+    # with a non-followup value
+
+    data = data.copy()
+
+    for question in question_or_section.questions:
+        for followup_id, values in question.get('followup', {}).items():
+            if data.get(question.id) not in values:
+                for field in question_or_section.get_question(followup_id).form_fields:
+                    data.pop(field, None)
+
+    return data

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -60,9 +60,16 @@ def template_all(item):
         return item
 
 
-def drop_followups(question_or_section, data):
-    # Remove any follow up answer if the question that requires followup has been answered
-    # with a non-followup value
+def drop_followups(question_or_section, data, nested=False):
+    """Remove any follow up answer if the lead-in question value doesn't require a follow up.
+
+    For nested questions (eg questions insidea a dynamic list array) we remove the question field
+    completely, since the top-level data key will be replaced anyway.
+
+    For multiquestions that are serialized to separate top-level keys we set the follow-up value
+    to `None`, so that it's replaced if the question was previously answered with a follow-up.
+
+    """
 
     data = data.copy()
 
@@ -70,6 +77,9 @@ def drop_followups(question_or_section, data):
         for followup_id, values in question.get('followup', {}).items():
             if data.get(question.id) not in values:
                 for field in question_or_section.get_question(followup_id).form_fields:
-                    data.pop(field, None)
+                    if nested:
+                        data.pop(field, None)
+                    else:
+                        data[field] = None
 
     return data

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -1,5 +1,7 @@
 import pytest
 
+from werkzeug.datastructures import MultiDict
+
 from dmcontent.utils import TemplateField
 from dmcontent.questions import Question, Multiquestion
 from dmcontent.content_loader import ContentSection
@@ -190,3 +192,23 @@ class TestFilterContentSection(object):
 
         assert section.filter({"lot": "digital-specialists"}).description == "description for specialists"
         assert section.filter({"lot": "digital-outcomes"}).description == "description for outcomes"
+
+    def test_question_followup_get_data(self):
+        section = ContentSection(
+            slug='section',
+            name=TemplateField('Section one'),
+            prefill=False,
+            editable=False,
+            edit_questions=False,
+            questions=[Question({'id': 'q1', 'followup': {'q2': [True]}, 'type': 'boolean'}),
+                       Question({'id': 'q2', 'type': 'boolean'})]
+        ).filter({})
+
+        assert section.get_data(MultiDict([('q1', 'true')])) == {'q1': True}
+        assert section.get_data(MultiDict([('q1', 'false')])) == {'q1': False}
+        assert section.get_data(
+            MultiDict([('q1', 'true'), ('q2', 'true')])
+        ) == {'q1': True, 'q2': True}
+        assert section.get_data(
+            MultiDict([('q1', 'false'), ('q2', 'true')])
+        ) == {'q1': False}

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -205,10 +205,10 @@ class TestFilterContentSection(object):
         ).filter({})
 
         assert section.get_data(MultiDict([('q1', 'true')])) == {'q1': True}
-        assert section.get_data(MultiDict([('q1', 'false')])) == {'q1': False}
+        assert section.get_data(MultiDict([('q1', 'false')])) == {'q1': False, 'q2': None}
         assert section.get_data(
             MultiDict([('q1', 'true'), ('q2', 'true')])
         ) == {'q1': True, 'q2': True}
         assert section.get_data(
             MultiDict([('q1', 'false'), ('q2', 'true')])
-        ) == {'q1': False}
+        ) == {'q1': False, 'q2': None}

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -200,15 +200,15 @@ class TestFilterContentSection(object):
             prefill=False,
             editable=False,
             edit_questions=False,
-            questions=[Question({'id': 'q1', 'followup': {'q2': [True]}, 'type': 'boolean'}),
+            questions=[Question({'id': 'q1', 'followup': {'q2': [False]}, 'type': 'boolean'}),
                        Question({'id': 'q2', 'type': 'boolean'})]
         ).filter({})
 
-        assert section.get_data(MultiDict([('q1', 'true')])) == {'q1': True}
-        assert section.get_data(MultiDict([('q1', 'false')])) == {'q1': False, 'q2': None}
-        assert section.get_data(
-            MultiDict([('q1', 'true'), ('q2', 'true')])
-        ) == {'q1': True, 'q2': True}
+        assert section.get_data(MultiDict([('q1', 'false')])) == {'q1': False}
+        assert section.get_data(MultiDict([('q1', 'true')])) == {'q1': True, 'q2': None}
         assert section.get_data(
             MultiDict([('q1', 'false'), ('q2', 'true')])
-        ) == {'q1': False, 'q2': None}
+        ) == {'q1': False, 'q2': True}
+        assert section.get_data(
+            MultiDict([('q1', 'true'), ('q2', 'true')])
+        ) == {'q1': True, 'q2': None}

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -298,10 +298,10 @@ class TestMultiquestion(QuestionTest):
             }
         ])
 
-        assert question.get_data({'lead': False}) == {'lead': False}
+        assert question.get_data({'lead': False}) == {'lead': False, 'follow': None}
         assert question.get_data({'lead': True}) == {'lead': True}
         assert question.get_data({'lead': True, 'follow': 'a'}) == {'lead': True, 'follow': 'a'}
-        assert question.get_data({'lead': False, 'follow': 'a'}) == {'lead': False}
+        assert question.get_data({'lead': False, 'follow': 'a'}) == {'lead': False, 'follow': None}
 
 
 class TestDynamicListQuestion(QuestionTest):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -281,7 +281,7 @@ class TestDynamicListQuestion(QuestionTest):
                     "id": "yesno",
                     "question": TemplateField("{{ item }}-yesno"),
                     "type": "boolean",
-                    "followup": "evidence"
+                    "followup": {"evidence": [True]}
                 },
                 {
                     "id": "evidence",

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -303,6 +303,47 @@ class TestMultiquestion(QuestionTest):
         assert question.get_data({'lead': True, 'follow': 'a'}) == {'lead': True, 'follow': 'a'}
         assert question.get_data({'lead': False, 'follow': 'a'}) == {'lead': False, 'follow': None}
 
+    def test_nested_checkboxes_question_followup_get_data(self):
+        question = self.question(questions=[
+            {
+                "id": "lead",
+                "type": "checkboxes",
+                "options": [
+                    {"label": "label1", "value": "yes"},
+                    {"label": "label2", "value": "no"},
+                    {"label": "label3", "value": "maybe not"},
+                    {"label": "label4", "value": "maybe"},
+                ],
+                "followup": {"follow": ["yes", "maybe"]}
+            },
+            {
+                "id": "follow",
+                "type": "text",
+            }
+        ])
+
+        assert question.get_data(OrderedMultiDict([
+            ('lead', 'no'),
+            ('lead', 'maybe not'),
+        ])) == {'lead': ['no', 'maybe not'], 'follow': None}
+
+        assert question.get_data(OrderedMultiDict([
+            ('lead', 'yes'),
+            ('lead', 'maybe not'),
+        ])) == {'lead': ['yes', 'maybe not']}
+
+        assert question.get_data(OrderedMultiDict([
+            ('lead', 'yes'),
+            ('lead', 'maybe not'),
+            ('follow', 'a')
+        ])) == {'lead': ['yes', 'maybe not'], 'follow': 'a'}
+
+        assert question.get_data(OrderedMultiDict([
+            ('lead', 'no'),
+            ('lead', 'maybe not'),
+            ('follow', 'a')
+        ])) == {'lead': ['no', 'maybe not'], 'follow': None}
+
 
 class TestDynamicListQuestion(QuestionTest):
     default_context = {'context': {'field': ['First Need', 'Second Need', 'Third Need', 'Fourth need']}}

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -266,6 +266,24 @@ class TestMultiquestion(QuestionTest):
 
         assert question.get_question('example2').question == "Question one"
 
+    def test_nested_question_followup_get_data(self):
+        question = self.question(questions=[
+            {
+                "id": "lead",
+                "type": "boolean",
+                "followup": {"follow": [True]}
+            },
+            {
+                "id": "follow",
+                "type": "text",
+            }
+        ])
+
+        assert question.get_data({'lead': False}) == {'lead': False}
+        assert question.get_data({'lead': True}) == {'lead': True}
+        assert question.get_data({'lead': True, 'follow': 'a'}) == {'lead': True, 'follow': 'a'}
+        assert question.get_data({'lead': False, 'follow': 'a'}) == {'lead': False}
+
 
 class TestDynamicListQuestion(QuestionTest):
     default_context = {'context': {'field': ['First Need', 'Second Need', 'Third Need', 'Fourth need']}}

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -148,6 +148,25 @@ class TestText(QuestionTest):
         assert self.question().get_question_ids(type='text') == ['example']
 
 
+class TestBoolean(QuestionTest):
+    def question(self, **kwargs):
+        data = {
+            "id": "example",
+            "type": "boolean"
+        }
+        data.update(kwargs)
+
+        return ContentQuestion(data)
+
+    def test_followup_values(self):
+        assert self.question(followup=OrderedDict(
+            [("q2", [True, False]), ("q3", [True])])
+        ).values_followup == {
+            True: ["q2", "q3"],
+            False: ["q2"]
+        }
+
+
 class TestPricing(QuestionTest):
     def question(self, **kwargs):
         data = {


### PR DESCRIPTION
## Add support for the followup questions to the multiquestion

Supports new followup YAML format.

Makes a separate _drop_followups method for the Multiquestions and
adds a call to it from `.get_data`.

It extends the method to support multi-input followup questions (eg
it should correctly drop all fields for a pricing followup), but it
still assumes that the original question data is stored in question
id key (which is true for most questions apart from multiquestions
and pricing, so they cannot have followups at the moment).

### Fix dynamic list filtering for schema generator

Schema generation calls `.filter` to create separate manifests for
separate framework lots, so that it can generate a schema for each
lot.

With the addition of DynamicList questions, filter now requires
dynamic data to generate the actual list of questions specific to
the brief, but that's not something we want to happen when listing
the questions for the schema generation. Schemas should contain
the original generic nested questions, so we need a separate way to
filter the manifests without doing the dynamic question replacements.

In order to achieve this, I'm adding a `static` flag to `.filter`,
which when set to True will make it skip the "dynamic" parts of
the filtering logic.

### Fix unicode error when printing questions with non-ascii characters

`__repr__` should return a string object in Python 2, so we need to
encode the template source beforehand.

### Add drop_followups call to ContentSection.get_data

G9 submissions are transforming multiquestions into sections before
rendering the page or processing form data, so ContentSection.get_data
method is replacing Multiquestion.get_data, which means we need to
implement drop_followups logic in both places at the moment (in
multiquestions for briefs and in sections for submissions).

### Add a reversed followup dict property for form templates

Form templates need a reversed followup structure: a list of question
ids that follow a certain question value. Since this is harder to do
in Jinja we add a helper property to Question that returns a reversed
followup dictionary.

### Make drop_followups return None values for top-level data fields

For nested questions (eg questions insidea a dynamic list array) we remove the question field
completely, since the top-level data key will be replaced anyway.

For multiquestions that are serialized to separate top-level keys we set the follow-up value
to `None`, so that it's replaced if the question was previously answered with a follow-up.