### PR TITLE
Checkbox summary values to equivalent labels

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '3.1.0'
+__version__ = '3.1.1'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -650,11 +650,19 @@ class PricingSummary(QuestionSummary, Pricing):
 class ListSummary(QuestionSummary, List):
     @property
     def value(self):
-        # TODO look up display values for options that have different labels from values
         if self.has_assurance():
             value = self._service_data.get(self.id, {}).get('value', '')
         else:
             value = self._service_data.get(self.id, '')
+
+        # Look up display values for options that have different labels from values
+        options = self.get('options')
+        if options and value:
+            for i, v in enumerate(value):
+                for option in options:
+                    if 'label' in option and 'value' in option and v == option['value']:
+                        value[i] = option['label']
+                        break
 
         if self.get('before_summary_value'):
             value = self.before_summary_value + (value or [])

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -644,17 +644,17 @@ class TestCheckboxesSummary(QuestionSummaryTest):
 
     def test_value(self):
         question = self.question().summary({'example': ['value1', 'value2']})
-        assert question.value == ['value1', 'value2']
+        assert question.value == ['Option label', 'Other label']
 
     def test_value_with_assurance(self):
         question = self.question(assuranceApproach='2answers-type1').summary(
             {'example': {'assurance': 'assurance value', 'value': ['value1', 'value2']}}
         )
-        assert question.value == ['value1', 'value2']
+        assert question.value == ['Option label', 'Other label']
 
     def test_value_with_before_summary_value(self):
         question = self.question(before_summary_value=['value0']).summary({'example': ['value1', 'value2']})
-        assert question.value == ['value0', 'value1', 'value2']
+        assert question.value == ['value0', 'Option label', 'Other label']
 
     def test_value_with_before_summary_value_if_empty(self):
         question = self.question(before_summary_value=['value0']).summary({})


### PR DESCRIPTION
CheckboySummary currently displays the stored (internal) rather than translating it to the equivalent label.

This PR performs the translation of values->labels upon retrieval.