### PR TITLE
Specify a default error message for 'answer required'.

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '3.3.0'
+__version__ = '3.4.0'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -126,7 +126,12 @@ class Question(object):
             if validation['name'] == message_key:
                 if validation.get('field', field_name) == field_name:
                     return validation['message']
-        return 'There was a problem with the answer to this question'
+
+        defaults = {
+            'answer_required': 'You need to answer this question.'
+        }
+
+        return defaults.get(message_key, 'There was a problem with the answer to this question.')
 
     @property
     def label(self):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1423,7 +1423,7 @@ class TestContentSection(object):
             }]
         })
 
-        expected = "There was a problem with the answer to this question"
+        expected = "There was a problem with the answer to this question."
         assert section.get_question('q2').get_error_message('other_error') == expected
 
     @pytest.mark.parametrize("question_descriptor_from", ("label", "question",))

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -455,30 +455,39 @@ class TestDynamicListQuestion(QuestionTest):
 
     def test_get_error_messages(self):
         question = self.question().filter(self.context())
-        ordered_dict = question.get_error_messages({'example': [
-            {'field': 'yesno', 'index': 0, 'error': 'answer_required'},
-            {'field': 'evidence', 'index': 0, 'error': 'answer_required'},
-            {'index': 1, 'error': 'answer_required'}
-        ]})
 
-        errors = list(ordered_dict.items())
-        assert errors == [
-            ('yesno-0', {
-                'input_name': 'yesno-0',
-                'message': 'There was a problem with the answer to this question',
-                'question': u'First Need-yesno'
-            }),
-            ('evidence-0', {
-                'input_name': 'evidence-0',
-                'message': 'There was a problem with the answer to this question',
-                'question': u'First Need-evidence'
-            }),
-            ('example', {
-                'input_name': 'example',
-                'message': 'There was a problem with the answer to this question',
-                'question': 'Dynamic list'
+        errors_and_messages = {
+            'answer_required': 'You need to answer this question.',
+            'some_unknown_error': 'There was a problem with the answer to this question.'
+        }
+
+        for error_key, expected_message in errors_and_messages.items():
+            ordered_dict = question.get_error_messages({
+                'example': [
+                    {'field': 'yesno', 'index': 0, 'error': error_key},
+                    {'field': 'evidence', 'index': 0, 'error': error_key},
+                    {'index': 1, 'error': error_key}
+                ]
             })
-        ]
+
+            errors = list(ordered_dict.items())
+            assert errors == [
+                ('yesno-0', {
+                    'input_name': 'yesno-0',
+                    'message': expected_message,
+                    'question': u'First Need-yesno'
+                }),
+                ('evidence-0', {
+                    'input_name': 'evidence-0',
+                    'message': expected_message,
+                    'question': u'First Need-evidence'
+                }),
+                ('example', {
+                    'input_name': 'example',
+                    'message': expected_message,
+                    'question': 'Dynamic list'
+                })
+            ]
 
 
 class TestCheckboxes(QuestionTest):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -454,6 +454,11 @@ class TestDynamicListQuestion(QuestionTest):
         assert question.get_error_messages({'example1': 'answer_required'}) == {}
 
     def test_get_error_messages(self):
+        """
+        Tests that for an 'answer_required' error, the content loader generates a suitable default,
+        and that for any other error it produces a generic message, and that the errors
+        come back in the right order.
+        """
         question = self.question().filter(self.context())
 
         errors_and_messages = {


### PR DESCRIPTION
The idea is that we should not have to repeat a standard error message in hundreds of question files, as we do at the moment.

Also added a full stop in the fallback error message, for consistency with the error messages we wrote into our YAML.