### PR TITLE
No longer persist parent values in the checkbox tree to the API.

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '3.1.1'
+__version__ = '3.1.2'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -692,6 +692,14 @@ class HierarchySummary(QuestionSummary):
             filtered_options = []
             for option in options:
                 value = option.get('value', option.get('label'))
+                # note: test below causes confusion if a non-selected child option has
+                # the same name as a parent option - that child will _appear_ selected
+                # if any of its siblings are selected.  Could refactor this
+                # if we wanted to have (e.g.) sub-cats named that way - right now
+                # we don't, and it's hard to see that making much sense. We've
+                # found more clear ways of expressing those kinds of special 'other'
+                # or 'general' sub-cats than naming them identically to their parents,
+                # anyway.
                 if value in selection or value in parent_values_not_persisted:
                     option = option.copy()
                     filtered_options.append(option)

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -546,13 +546,8 @@ class TestCheckboxTree(QuestionTest):
 
     def test_get_data(self):
         assert self.question().get_data(
-            OrderedMultiDict([('example', 'value_1'), ('example', 'value_2')])
-        ) == {'example': ['value_1', 'value_2']}
-
-    def test_automatic_parent(self):
-        assert set(self.question().get_data(
-            OrderedMultiDict([('example', 'value_1_2'), ('example', 'value_2_1')])
-        ).get('example')) == set(('value_1', 'value_1_2', 'value_2', 'value_2_1', ))
+            OrderedMultiDict([('example', 'value_1_1'), ('example', 'value_2_1')])
+        ) == {'example': ['value_1_1', 'value_2_1']}
 
     def test_get_data_unknown_key(self):
         assert self.question().get_data({'other': 'other value'}) == {'example': None}
@@ -693,26 +688,24 @@ class TestCheckboxTreeSummary(QuestionSummaryTest):
         return ContentQuestion(data)
 
     def test_value(self):
-        question = self.question().summary({'example': ['val1', 'val1.1', 'val2.2', 'val4']})
+        question = self.question().summary({'example': ['val1.1', 'val2.2', 'val4']})
         assert question.value == [
                 {
                     "label": "Option 1",
                     "value": "val1",
-                    "missing": False,
                     "options": [
-                        {"label": "Option 1.1", "value": "val1.1", "missing": False, "options": []},
+                        {"label": "Option 1.1", "value": "val1.1", "options": []},
                     ]
                 },
                 {
                     "label": "Option 2",
                     "value": "val2",
-                    "missing": True,
                     "options": [
-                        {"label": "Option 2.2", "value": "val2.2", "missing": False, "options": []},
+                        {"label": "Option 2.2", "value": "val2.2", "options": []},
                     ]
                 },
 
-                {"label": "Option 4", "value": "val4", "missing": False, "options": []},
+                {"label": "Option 4", "value": "val4", "options": []},
             ]
 
     def test_value_missing(self):


### PR DESCRIPTION
 - https://trello.com/c/y79rP1KA/197-suppliers-choose-a-category-backend
 - implements 'decision re validation / parent categories' (see ticket)