### PR TITLE
Add support for subfield TemplateFields

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '3.1.1'
+__version__ = '3.3.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -503,6 +503,13 @@ class ContentLoader(object):
             if field in question_data:
                 question_data[field] = TemplateField(question_data[field])
 
+        # We also want to support TemplateFields as subfields of entries in options (e.g. for lot descriptions)
+        for subfield in Question.TEMPLATE_OPTIONS_FIELDS:
+            if 'options' in question_data:
+                for i, option in enumerate(question_data['options']):
+                    if subfield in option:
+                        question_data['options'][i][subfield] = TemplateField(question_data['options'][i][subfield])
+
         self._questions[framework_slug][question_set][question] = question_data
 
         return self._questions[framework_slug][question_set][question].copy()

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -7,6 +7,7 @@ from .utils import TemplateField, drop_followups
 
 class Question(object):
     TEMPLATE_FIELDS = ['name', 'question', 'hint', 'question_advice']
+    TEMPLATE_OPTIONS_FIELDS = ['description']
 
     def __init__(self, data, number=None, _context=None):
         self.number = number
@@ -193,6 +194,11 @@ class Question(object):
 
         if isinstance(field, TemplateField):
             return field.render(self._context)
+        elif key == 'options':
+            return [{k: (v.render(self._context) if isinstance(v, TemplateField) else v)
+                     for k, v in i.items()
+                     }
+                    for i in field]
         else:
             return field
 

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import pytest
 
 from werkzeug.datastructures import OrderedMultiDict
+from markupsafe import Markup
 from dmcontent.content_loader import ContentQuestion
 from dmcontent.utils import TemplateField
 from dmcontent import ContentTemplateError
@@ -107,6 +108,19 @@ class QuestionTest(object):
             question.name
 
         assert question.question == "Question"
+
+    def test_question_options_descriptions_render_template_fields(self):
+        """If the question has an options field, check that all TEMPLATE_OPTIONS_FIELDS are correctly rendered from
+        TemplateFields by passing in markup and ensuring they turn into Markup objects.
+        Does not recurse through options.options.[...] fields, e.g. for CheckboxTree"""
+        question = self.question()
+
+        if hasattr(question, 'options'):
+            options = question['options']
+            for subfield in question.TEMPLATE_OPTIONS_FIELDS:
+                for option in options:
+                    if subfield in option:
+                        assert type(option[subfield]) == Markup
 
 
 class TestText(QuestionTest):
@@ -473,7 +487,8 @@ class TestCheckboxes(QuestionTest):
             "id": "example",
             "type": "checkboxes",
             "options": [
-                {"label": "Wrong label", "value": "value"},
+                {"label": "Wrong label", "value": "value", "description": TemplateField("some description"
+                                                                                        " [markup](links)")},
                 {"label": "Option label", "value": "value1"},
                 {"label": "Wrong label", "value": "value2"},
             ]
@@ -502,6 +517,36 @@ class TestCheckboxes(QuestionTest):
         assert self.question(assuranceApproach='2answers-type1').get_data(
             {'example--assurance': 'assurance value'}
         ) == {'example': {'assurance': 'assurance value'}}
+
+
+class TestRadios(TestCheckboxes):
+    def question(self, **kwargs):
+        data = {
+            "id": "example",
+            "type": "radios",
+            "options": [
+                {"label": "Wrong label", "value": "value", "description": TemplateField("some description"
+                                                                                        " [markup](links)")},
+                {"label": "Option label", "value": "value1"},
+                {"label": "Wrong label", "value": "value2"},
+            ]
+        }
+        data.update(kwargs)
+
+        return ContentQuestion(data)
+
+    def test_get_data(self):
+        assert self.question().get_data(
+            OrderedMultiDict([('example', 'value1')])
+        ) == {'example': 'value1'}
+
+    def test_get_data_unknown_key(self):
+        assert self.question().get_data({'other': 'other value'}) == {}
+
+    def test_get_data_with_assurance(self):
+        assert self.question(assuranceApproach='2answers-type1').get_data(
+            OrderedMultiDict([('example', 'value1'), ('example--assurance', 'assurance value')])
+        ) == {'example': {'value': 'value1', 'assurance': 'assurance value'}}
 
 
 class TestCheckboxTree(QuestionTest):


### PR DESCRIPTION
* Lot descriptions are currently stored in services/lots.yml for each framework, roughly working like a radios question.
* Descriptions for each possible choice are stored in options[x].description.
* Adds a TEMPLATE_OPTIONS_SUBFIELDS variable to Question to specify which subfields under options should be turned into TemplateFields and rendered appropriately.
* This check in options subfields does not iterate down beyond the first level, so will not work with - e.g. - CheckboxTree. 