### PR TITLE
[#141001837]get_error_messages methods: add keyword argument question_descriptor_from

### DIFF
--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -338,7 +338,7 @@ class ContentSection(object):
             any(form_field not in service for form_field in self.get_field_names())
         ])
 
-    def get_error_messages(self, errors):
+    def get_error_messages(self, errors, question_descriptor_from="label"):
         """Convert API error keys into error messages
 
         :param errors: error dictionary as returned by the data API
@@ -349,7 +349,7 @@ class ContentSection(object):
 
         errors_map = OrderedDict()
         for question in self.questions:
-            errors_map.update(question.get_error_messages(errors))
+            errors_map.update(question.get_error_messages(errors, question_descriptor_from=question_descriptor_from))
 
         return errors_map
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -86,7 +86,7 @@ class Question(object):
 
         return {self.id: value}
 
-    def get_error_messages(self, errors):
+    def get_error_messages(self, errors, question_descriptor_from="label"):
         error_fields = set(errors.keys()) & set(self.form_fields)
         if not error_fields:
             return {}
@@ -104,7 +104,7 @@ class Question(object):
 
             question_errors[error_key] = {
                 'input_name': error_key,
-                'question': question.label,
+                'question': getattr(question, question_descriptor_from),
                 'message': validation_message,
             }
 
@@ -388,7 +388,7 @@ class DynamicList(Multiquestion):
                 result[key] = data[key]
         return result
 
-    def get_error_messages(self, errors):
+    def get_error_messages(self, errors, question_descriptor_from="label"):
         if self.id not in errors:
             return {}
 
@@ -407,7 +407,7 @@ class DynamicList(Multiquestion):
             question = self.get_question(input_name)
             question_errors[input_name] = {
                 'input_name': input_name,
-                'question': question.label,
+                'question': getattr(question, question_descriptor_from),
                 'message':  question.get_error_message(error['error']),
             }
 
@@ -537,9 +537,12 @@ class QuestionSummary(Question):
     def _default_for_field(self, field_key):
         return self.get('field_defaults', {}).get(field_key)
 
-    def get_error_messages(self, errors):
+    def get_error_messages(self, errors, question_descriptor_from="label"):
 
-        question_errors = super(QuestionSummary, self).get_error_messages(errors)
+        question_errors = super(QuestionSummary, self).get_error_messages(
+            errors,
+            question_descriptor_from=question_descriptor_from,
+        )
 
         boolean_list_questions = self.get('boolean_list_questions')
         boolean_list_values = self.get('value') or []

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1426,7 +1426,8 @@ class TestContentSection(object):
         expected = "There was a problem with the answer to this question"
         assert section.get_question('q2').get_error_message('other_error') == expected
 
-    def test_get_error_messages(self):
+    @pytest.mark.parametrize("question_descriptor_from", ("label", "question",))
+    def test_get_error_messages(self, question_descriptor_from):
         section = ContentSection.create({
             "slug": "second_section",
             "name": "Second section",
@@ -1481,11 +1482,11 @@ class TestContentSection(object):
             "priceString-min": "answer_required",
         }
 
-        result = section.get_error_messages(errors)
+        result = section.get_error_messages(errors, question_descriptor_from=question_descriptor_from)
 
         assert result['priceString']['message'] == "No min price"
         assert result['q2']['message'] == "This is the error message"
-        assert result['q2']['question'] == "second"
+        assert result['q2']['question'] == "Second question" if question_descriptor_from == "question" else "second"
         assert result['q3--assurance']['message'] == "There there, it'll be ok."
         assert result['serviceTypes']['message'] == "This is the error message"
 


### PR DESCRIPTION
to allow caller to specify how it would like questions to be referred to in an error's "question" field.

Story https://www.pivotaltracker.com/story/show/141001837

This seemed to be the quickest most pragmatic way to enable me to fix this in the time permitted.