### PR TITLE
Drop everything except letters and numbers before generating slugs

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '3.5.0'
+__version__ = '3.5.1'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -589,7 +589,7 @@ def _load_question(question, directory):
 
 def _make_slug(name):
     return inflection.underscore(
-        re.sub(r"[\s&?]", "_", name, flags=re.UNICODE).strip("_")
+        re.sub(r"[^\w]+", "_", name, flags=re.UNICODE).strip("_")
     ).replace('_', '-')
 
 


### PR DESCRIPTION
* Drop everything except letters and numbers (regex \w) from ids/names before generating the slug.
* Bump version to 5.3.1