### PR TITLE
Fix dynamic lists

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '3.5.1'
+__version__ = '3.5.2'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -297,9 +297,7 @@ class DynamicList(Multiquestion):
             return None
 
         # dynamic_field: 'brief.essentialRequirements'
-        dynamic_questions = context
-        for key in self.dynamic_field.split('.'):
-            dynamic_questions = dynamic_questions[key]
+        dynamic_questions = self.get_dynamic_questions(context)
 
         dynamic_list.questions = list(filter(None, [
             self._make_dynamic_question(question, item, index)
@@ -308,6 +306,13 @@ class DynamicList(Multiquestion):
         ]))
 
         return dynamic_list
+
+    def get_dynamic_questions(self, context):
+        """ Returns the value of the dynamic.field from the context """
+        dynamic_questions = context
+        for key in self.dynamic_field.split('.'):
+            dynamic_questions = dynamic_questions[key]
+        return dynamic_questions
 
     def get_data(self, form_data):
         """
@@ -351,7 +356,7 @@ class DynamicList(Multiquestion):
 
         answers = sorted([(int(k.split('-')[1]), k.split('-')[0], v) for k, v in q_data.items()])
 
-        questions_data = [{} for i in range(1 + (answers[-1][0]))]
+        questions_data = [{} for i in range(len(self.get_dynamic_questions(self._context)))]
         for index, question, value in answers:
             if value is not None:
                 questions_data[index][question] = value

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -406,7 +406,9 @@ class TestDynamicListQuestion(QuestionTest):
         assert question.get_data({
             'yesno-0': True,
             'evidence-0': 'some evidence',
+            'evidence-1': '',
             'yesno-2': False,
+            'evidence-2': '',
             'yesno-3': False,
             'evidence-3': 'should be removed'
         }
@@ -425,6 +427,40 @@ class TestDynamicListQuestion(QuestionTest):
                 {
                     'yesno': False
                 }
+            ]
+        }
+
+        assert question.get_data({
+            'evidence-2': '',
+            'evidence-1': '',
+            'evidence-0': '',
+            'evidence-3': ''
+        }
+        ) == {
+            'example': [
+                {},
+                {},
+                {},
+                {}
+            ]
+        }
+
+        assert question.get_data({
+            'evidence-2': 'some evidence',
+            'evidence-1': '',
+            'evidence-0': '',
+            'yesno-2': True,
+            'evidence-3': ''
+        }
+        ) == {
+            'example': [
+                {},
+                {},
+                {
+                    'yesno': True,
+                    'evidence': 'some evidence'
+                },
+                {}
             ]
         }
 


### PR DESCRIPTION
For [this pivotal story](https://www.pivotaltracker.com/story/show/141314099)

Before version 3.0.0 of the content loader, for dynamic lists we were dropping followup fields if the followup question had been answered `False` as such:
```
for question in self.questions:
    if question.get('followup'):
        if q_data.get(question.id) is False:
            q_data.pop(question.followup, None)
```

This behaviour was then replaced by the `drop_followups` util method in 3.0.0.

Also note that evidence fields are always sent in a POST request as they are textareas even if they are empty but radio buttons are not if unanswered.

For the below examples, please look at [the 3.0.0 PR](https://github.com/alphagov/digitalmarketplace-content-loader/pull/25/files) so you can follow along with both 2.9.0 and 3.0.0 for the following code snippets.

### 2.9.0 behaviour for a brief with two nice to have requirements relying on 'buggy' follow up dropping
```
form_data = {"yesNo-0": False, "evidence-0: "", "evidence-1": ""}
```
q_data after follows up had been 'dropped'
```
q_data == {"yesNo-0": False, "evidence-1": ""} # undesired behaviour, evidence-1 should also have been removed
answers = sorted([(int(k.split('-')[1]), k.split('-')[0], v) for k, v in q_data.items()])
len(answers) == 2
```
And therefore
```
question.get_data(form_data) == [{'yesNo': False}, {}]
```

### 3.0.0 behaviour for a brief with two nice to have requirements relying on 'correct' follow up dropping
```
form_data = {"yesNo-0": False, "evidence-0: "", "evidence-1": ""}
```
q_data after follows up had been 'dropped'
```
q_data == {"yesNo-0": False}
answers = sorted([(int(k.split('-')[1]), k.split('-')[0], v) for k, v in q_data.items()])
len(answers) == 1
```
And therefore
```
question.get_data(form_data) == [{'yesNo': False}]
```

### Why this was causing issues
The API expects to receive the same number of items as the number of nice to have requirements, otherwise it will throw a very generic error `'niceToHaveRequirements': 'answer_required'` rather than dict of errors indexed errors (e.g. answer required for niceToHaveRequirements on field 'yesNo' with index 2)

Because our front end couldn't handle a generic error  it wasn't expecting the page (which would occur if the last niceToHaveRequirements question had not been answered) would fall over and cause 500's.

### Solution
Now the list returned from `question.get_data` will always contain the same number of items as the number of dynamic questions. For example for brief with two nice to have requirements, `question.get_data` will always return a list with 2 items (even if those items are empty) regardless of the form input.