### PR TITLE
Fix unanswered questions count

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '3.5.2'
+__version__ = '3.5.3'

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -341,7 +341,10 @@ class TestContentManifest(object):
                     "type": "multiquestion",
                     "questions": [
                         {"id": "q2", "type": "text"},
-                        {"id": "q3", "type": "text"}
+                        {"id": "q3", "type": "text"},
+                        {"id": "q12", "type": "boolean", "followup": {"q13": [True], "q14": [True]}},
+                        {"id": "q13", "type": "text"},
+                        {"id": "q14", "type": "text", "optional": True}
                     ]
                 },
                 {"id": "q4", "type": "text", "optional": True},
@@ -416,6 +419,10 @@ class TestContentManifest(object):
         assert not summary.get_question('q9').answer_required
         assert summary.get_question('q10').value is True
         assert summary.get_question('q10').assurance == 'Service provider assertion'
+
+        assert summary.get_question('q12').answer_required
+        assert summary.get_question('q13').answer_required
+        assert not summary.get_question('q14').answer_required
 
     def test_get_question(self):
         content = ContentManifest([


### PR DESCRIPTION
This PR fixes a bug in the 'answer_required' property for MultiquestionSummary, caused by a lack of knowledge about questions with followups.

Previously, MultiquestionSummaries would only do the following:
* Check all questions and return True if any of those questions require an answer.

This would cause most questions-with-dependencies to incorrectly return True if the answers given by a user did not provide answers for all questions because some of the questions were not required followups.

To fix this, a MultiquestionSummary will now do three things:
* If the multiquestion itself is marked as optional, return False.
* Iterate over all questions that have followups. For each one, if it requires answer return True. If it doesn't, check whether each of its followup are 1) required (i.e. not optional), and 2) require an answer (via its own answer_required). If yes, return True.
* Check all remaining questions (those which do not have followups, and which are not followups of other questions), and return True if any of those require an answer (via their own answer_required).