### PR TITLE
141882981-Add-question-type-to-content-loader-and-summary-display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 Records breaking changes from major version bumps
 
+## 4.0.0
+
+PR: [#36](https://github.com/alphagov/digitalmarketplace-content-loader/pull/36/files)
+
+### What changed
+
+New question type `Date` and non-backwards compatible change to `Question.unformat_data` which now returns only data
+relevant to the given question.
+
+### Example Change
+
+#### Old
+```
+        >>> question.unformat_data({"thisQuestion": 'some data', "notThisQuestion": 'other data'})
+        {"thisQuestion": 'some data changed by unformat method', "notThisQuestion": 'other data'}
+```
+#### New
+```
+        >>> question.unformat_data({"thisQuestion": 'some data', "notThisQuestion": 'other data'})
+        {"thisQuestion": 'some data changed by unformat method'}
+```
+
+
 ## 3.0.0
 
 PR: [#25](https://github.com/alphagov/digitalmarketplace-content-loader/pull/25)
@@ -12,7 +35,6 @@ Added support for `followup` questions inside multiquestions, radio questions wi
 and multiple followups for a single question. This requires changing the question YAML file
 syntax for listing followups, so the content loader is modified to support the new format
 and will only work with an updated frameworks repo.
-
 
 ### Example change
 

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '3.7.0'
+__version__ = '4.0.0'

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '3.6.0'
+__version__ = '3.7.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -386,7 +386,7 @@ class ContentSection(object):
                 question = self.get_question(key)
                 if question:
                     # Otherwise if it is a legitimate question use the unformat method on the question.
-                    result.update(question.unformat_data(data))
+                    result.update(question.unformat_data(key, data))
                 else:
                     # Otherwise it's not a question, default to returning the k: v pair.
                     result[key] = data[key]

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -361,8 +361,7 @@ class ContentSection(object):
         }
 
     def unformat_data(self, data):
-
-        """Unpack assurance information to be used in a form
+        """Method to process form data, special assurance case or individual question level unformat.
 
         :param data: the service data as returned from the data API
         :type data: dict

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -363,8 +363,10 @@ class ContentSection(object):
     @staticmethod
     def unformat_date(key, data):
         result = {}
-        for value, field in zip(data[key].split('-'), Date.FIELDS):
-            result['-'.join([key, field])] = value
+        value = data[key]
+        if data[key]:
+            for partial_value, field in zip(value.split('-'), Date.FIELDS):
+                result['-'.join([key, field])] = partial_value
         return result
 
     def unformat_data(self, data):

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -11,7 +11,7 @@ from functools import partial
 from werkzeug.datastructures import ImmutableMultiDict
 
 from .errors import ContentNotFoundError, QuestionNotFoundError
-from .questions import Question, ContentQuestion, Date
+from .questions import Question, ContentQuestion
 from .messages import ContentMessage
 from .utils import TemplateField, template_all, drop_followups
 

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -361,7 +361,7 @@ class ContentSection(object):
         }
 
     def unformat_data(self, data):
-        """Method to process form data, special assurance case or individual question level unformat.
+        """Method to process data into format for form, special assurance case or individual question level unformat.
 
         :param data: the service data as returned from the data API
         :type data: dict

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -385,7 +385,7 @@ class ContentSection(object):
                 question = self.get_question(key)
                 if question:
                     # Otherwise if it is a legitimate question use the unformat method on the question.
-                    result.update(question.unformat_data(key, data))
+                    result.update(question.unformat_data(data))
                 else:
                     # Otherwise it's not a question, default to returning the k: v pair.
                     result[key] = data[key]

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -115,7 +115,7 @@ class Question(object):
         return question_errors
 
     def unformat_data(self, data):
-        return {self.id: data[self.id]}
+        return {self.id: data.get(self.id, None)}
 
     def get_error_message(self, message_key, field_name=None):
         """Return a single error message.
@@ -395,19 +395,19 @@ class DynamicList(Multiquestion):
             "yesno-0": True,
             "yesno-1": False,
             "evidence-0": "Yes, I did."
-            "nonDynamicListKey": 'other data'
         }
         """
         result = {}
-        for key in data:
-            if key == self.id:
-                for question in self.questions:
-                    # For each question e.g. evidence-0, find if data exists for it and insert it into our result
-                    root, index = question.id.split('-')
-                    if root in data[self.id][int(index)]:
-                        result[question.id] = data[self.id][int(index)].get(root)
-            else:
-                result[key] = data[key]
+        dynamic_list_data = data.get(self.id, None)
+        if not dynamic_list_data:
+            return result
+        for question in self.questions:
+            # For each question e.g. evidence-0, find if data exists for it and insert it into our result
+            root, index = question.id.split('-')
+            question_data = dynamic_list_data[int(index)]
+            if root in question_data:
+                result.update({question.id: question_data.get(root)})
+
         return result
 
     def get_error_messages(self, errors, question_descriptor_from="label"):
@@ -586,7 +586,7 @@ class Date(Question):
     def unformat_data(self, data):
         result = {}
         value = data[self.id]
-        if data[self.id]:
+        if value:
             for partial_value, field in zip(value.split('-'), self.FIELDS):
                 result['-'.join([self.id, field])] = partial_value
         return result

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -555,6 +555,14 @@ class Date(Question):
     def summary(self, service_data):
         return DateSummary(self, service_data)
 
+    @staticmethod
+    def process_value(value):
+        """If there are any hyphens in the value then it does not validate."""
+        value = value.strip()
+        if not value or '-' in value:
+            return ''
+        return value
+
     def get_data(self, form_data):
         """Retreive the fields from the POST data (form_data).
 
@@ -565,8 +573,8 @@ class Date(Question):
         parts = []
         for key in self.FIELDS:
             identifier = '-'.join([self.id, key])
-            value = form_data.get(identifier, '').replace('-', '').strip()
-            parts.append(value or '')
+            value = form_data.get(identifier, '')
+            parts.append(self.process_value(value))
 
         return {self.id: '-'.join(parts) if any(parts) else None}
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -7,7 +7,6 @@ from .formats import format_price
 from .utils import TemplateField, drop_followups
 
 
-
 class Question(object):
     TEMPLATE_FIELDS = ['name', 'question', 'hint', 'question_advice']
     TEMPLATE_OPTIONS_FIELDS = ['description']

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -672,7 +672,7 @@ class DateSummary(QuestionSummary):
     @property
     def value(self):
         try:
-            return datetime.strptime(self._value, '%Y-%m-%d').strftime('%-d %B %Y')
+            return datetime.strptime(self._value, '%Y-%m-%d').strftime('%A %-d %B %Y')
         except ValueError:
             return self._value
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -468,14 +468,16 @@ class Pricing(Question):
             return self
 
     def unformat_data(self, data):
-        return self.get_data(data)
+        """Get values from api data whose keys are in self.fields; this indicates they are related to this question."""
+        return {key: data[key] for key in data if key in self.fields.values()}
 
     def get_data(self, form_data):
-        return {
-            key: form_data[key] if form_data[key] else None
-            for key in self.fields.values()
-            if key in form_data
-        }
+        """
+        Return a subset of form_data containing only those key: value pairs whose key appears in the self.fields of
+        this question (therefore only those pairs relevant to this question).
+        Filter 0/ False values here and replace with None as they are handled with the optional flag.
+        """
+        return {key: form_data[key] or None for key in self.fields.values() if key in form_data}
 
     @property
     def form_fields(self):

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -185,10 +185,6 @@ class Question(object):
     def has_assurance(self):
         return True if self.get('assuranceApproach') else False
 
-    @property
-    def is_date(self):
-        return False
-
     def get_question_ids(self, type=None):
         return [self.id] if type in [self.type, None] else []
 
@@ -556,10 +552,6 @@ class Date(Question):
 
     FIELDS = ('year', 'month', 'day')
 
-    @property
-    def is_date(self):
-        return True
-
     def summary(self, service_data):
         return DateSummary(self, service_data)
 
@@ -579,7 +571,6 @@ class Date(Question):
         return {self.id: '-'.join(parts) if any(parts) else None}
 
     def unformat_data(self, data):
-
         result = {}
         value = data[self.id]
         if data[self.id]:

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -573,9 +573,11 @@ class Date(Question):
         parts = []
         for key in self.FIELDS:
             identifier = '-'.join([self.id, key])
-            parts.append(form_data.get(identifier, None))
-        if not all(parts):
-            return {}
+            value = form_data.get(identifier, '').strip()
+            if not value:
+                return {self.id: None}
+            parts.append(value.strip())
+
         return {self.id: '-'.join(parts)}
 
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -573,10 +573,19 @@ class Date(Question):
         parts = []
         for key in self.FIELDS:
             identifier = '-'.join([self.id, key])
-            value = form_data.get(identifier, '').strip()
-            parts.append(value.strip() or '')
+            value = form_data.get(identifier, '').replace('-', '').strip()
+            parts.append(value or '')
 
         return {self.id: '-'.join(parts) if any(parts) else None}
+
+    def unformat_data(self, data):
+
+        result = {}
+        value = data[self.id]
+        if data[self.id]:
+            for partial_value, field in zip(value.split('-'), self.FIELDS):
+                result['-'.join([self.id, field])] = partial_value
+        return result
 
 
 class QuestionSummary(Question):
@@ -672,6 +681,8 @@ class DateSummary(QuestionSummary):
         try:
             return datetime.strptime(self._value, DATE_FORMAT).strftime(DISPLAY_DATE_FORMAT)
         except ValueError:
+            # We may need to fall back to displaying a plain string value in the case of briefs in draft before
+            # the date field was introduced.
             return self._value
 
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -114,8 +114,8 @@ class Question(object):
 
         return question_errors
 
-    def unformat_data(self, data):
-        return data
+    def unformat_data(self, key, data):
+        return {key: data[key]}
 
     def get_error_message(self, message_key, field_name=None):
         """Return a single error message.
@@ -369,7 +369,7 @@ class DynamicList(Multiquestion):
 
         return {self.id: questions_data}
 
-    def unformat_data(self, data):
+    def unformat_data(self, key, data):
         """ Unpack service data to be used in a form
 
         :param data: the service data as returned from the data API
@@ -558,7 +558,7 @@ class Date(Question):
     @staticmethod
     def process_value(value):
         """If there are any hyphens in the value then it does not validate."""
-        value = value.strip()
+        value = value.strip() if value else ''
         if not value or '-' in value:
             return ''
         return value
@@ -578,7 +578,7 @@ class Date(Question):
 
         return {self.id: '-'.join(parts) if any(parts) else None}
 
-    def unformat_data(self, data):
+    def unformat_data(self, key, data):
         result = {}
         value = data[self.id]
         if data[self.id]:

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -98,7 +98,6 @@ class Question(object):
         for field_name in sorted(error_fields):
             question = self.get_question(field_name)
             message_key = errors[field_name]
-
             validation_message = question.get_error_message(message_key, field_name)
 
             error_key = question.id
@@ -566,18 +565,16 @@ class Date(Question):
         """Retreive the fields from the POST data (form_data).
 
         The d, m, y should be in the post as 'questionName-day', questionName-month ...
-        Extract them and format as 'YYYY-MM-DD'.
+        Extract them and format as '\d\d\d\d-\d{1,2}-\d{1,2}'.
         https://code.tutsplus.com/tutorials/validating-data-with-json-schema-part-1--cms-25343
         """
         parts = []
         for key in self.FIELDS:
             identifier = '-'.join([self.id, key])
             value = form_data.get(identifier, '').strip()
-            if not value:
-                return {self.id: None}
-            parts.append(value.strip())
+            parts.append(value.strip() or '')
 
-        return {self.id: '-'.join(parts)}
+        return {self.id: '-'.join(parts) if any(parts) else None}
 
 
 class QuestionSummary(Question):

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -114,8 +114,8 @@ class Question(object):
 
         return question_errors
 
-    def unformat_data(self, key, data):
-        return {key: data[key]}
+    def unformat_data(self, data):
+        return {self.id: data[self.id]}
 
     def get_error_message(self, message_key, field_name=None):
         """Return a single error message.
@@ -369,7 +369,7 @@ class DynamicList(Multiquestion):
 
         return {self.id: questions_data}
 
-    def unformat_data(self, key, data):
+    def unformat_data(self, data):
         """ Unpack service data to be used in a form
 
         :param data: the service data as returned from the data API
@@ -466,6 +466,9 @@ class Pricing(Question):
     def get_question(self, field_name):
         if self.id == field_name or field_name in self.fields.values():
             return self
+
+    def unformat_data(self, data):
+        return self.get_data(data)
 
     def get_data(self, form_data):
         return {
@@ -578,7 +581,7 @@ class Date(Question):
 
         return {self.id: '-'.join(parts) if any(parts) else None}
 
-    def unformat_data(self, key, data):
+    def unformat_data(self, data):
         result = {}
         value = data[self.id]
         if data[self.id]:

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict, defaultdict
 from datetime import datetime
 
+from dmutils.formats import DATE_FORMAT, DISPLAY_DATE_FORMAT
+
 from .converters import convert_to_boolean, convert_to_number
 from .errors import ContentNotFoundError
 from .formats import format_price
@@ -668,7 +670,7 @@ class DateSummary(QuestionSummary):
     @property
     def value(self):
         try:
-            return datetime.strptime(self._value, '%Y-%m-%d').strftime('%A %-d %B %Y')
+            return datetime.strptime(self._value, DATE_FORMAT).strftime(DISPLAY_DATE_FORMAT)
         except ValueError:
             return self._value
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 -e .
+git+https://github.com/alphagov/digitalmarketplace-utils.git@25.0.1#egg=digitalmarketplace-utils==25.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pep8]
-exclude = ./venv
+exclude = ./venv*
 max-line-length = 120
 
 [pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ exclude = ./venv
 max-line-length = 120
 
 [pytest]
-norecursedirs = venv
+norecursedirs = venv*

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
         'Werkzeug==0.11.9',
         'inflection==0.3.1',
         'six==1.10.0'
-    ],
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,4 @@ setup(
         'inflection==0.3.1',
         'six==1.10.0'
     ],
-    dependency_links=[
-        'git+https://github.com/alphagov/digitalmarketplace-utils.git@25.0.1#egg=digitalmarketplace-utils==25.0.1'
-    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,8 @@ setup(
         'Werkzeug==0.11.9',
         'inflection==0.3.1',
         'six==1.10.0'
+    ],
+    dependency_links=[
+        'git+https://github.com/alphagov/digitalmarketplace-utils.git@25.0.1#egg=digitalmarketplace-utils==25.0.1'
     ]
 )

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1699,7 +1699,7 @@ class TestContentSection(object):
 
 
 class TestReadYaml(object):
-    @ mock.patch('dmcontent.content_loader.open', return_value=io.StringIO(u'foo: bar'))
+    @mock.patch('dmcontent.content_loader.open', return_value=io.StringIO(u'foo: bar'))
     def test_loading_existant_file(self, mocked_open):
         assert read_yaml('anything.yml') == {'foo': 'bar'}
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1699,11 +1699,11 @@ class TestContentSection(object):
 
 
 class TestReadYaml(object):
-    @mock.patch.object(builtins, 'open', return_value=io.StringIO(u'foo: bar'))
+    @ mock.patch('dmcontent.content_loader.open', return_value=io.StringIO(u'foo: bar'))
     def test_loading_existant_file(self, mocked_open):
         assert read_yaml('anything.yml') == {'foo': 'bar'}
 
-    @mock.patch.object(builtins, 'open', side_effect=IOError)
+    @ mock.patch('dmcontent.content_loader.open', side_effect=IOError)
     def test_file_not_found(self, mocked_open):
         with pytest.raises(IOError):
             assert read_yaml('something.yml')

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1703,7 +1703,7 @@ class TestReadYaml(object):
     def test_loading_existant_file(self, mocked_open):
         assert read_yaml('anything.yml') == {'foo': 'bar'}
 
-    @ mock.patch('dmcontent.content_loader.open', side_effect=IOError)
+    @mock.patch('dmcontent.content_loader.open', side_effect=IOError)
     def test_file_not_found(self, mocked_open):
         with pytest.raises(IOError):
             assert read_yaml('something.yml')

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -188,13 +188,13 @@ class TestDates(QuestionTest):
         assert self.question().get_data({
             'example-day': '19',
             'example-month': '03',
-        }) == {'example': None}
+        }) == {'example': '-03-19'}
 
         assert self.question().get_data({
             'example-day': '19',
             'example-month': '03',
             'example-year': ' ',
-        }) == {'example': None}
+        }) == {'example': '-03-19'}
 
     def test_get_data_with_blank_year(self):
         assert self.question().get_data({
@@ -729,6 +729,10 @@ class TestDateSummary(QuestionSummaryTest):
     def test_date_is_formatted_into_user_friendly_format(self):
         question = self.question().summary({'example': '2016-02-18'})
         assert question.value == 'Thursday 18 February 2016'
+
+    def test_unpadded_date_is_formatted_into_user_friendly_format(self):
+        question = self.question().summary({'example': '2003-2-1'})
+        assert question.value == 'Saturday 1 February 2003'
 
     def test_not_a_date_format_falls_back_to_raw_string(self):
         non_date_string = 'not-a-date-formatted-string'

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -676,6 +676,24 @@ class QuestionSummaryTest(object):
         assert question.is_empty
 
 
+class TestDateSummary(QuestionSummaryTest):
+
+    def question(self, **kwargs):
+        data = {
+            "id": "example",
+            "type": "date"
+        }
+        data.update(kwargs)
+
+        return ContentQuestion(data)
+
+    def test_invalid_string(self):
+        non_date_string = 'not-a-date-formatted-string'
+        question = self.question().summary({'example': non_date_string})
+
+        assert question.value == ''+non_date_string
+
+
 class TestTextSummary(QuestionSummaryTest):
     def question(self, **kwargs):
         data = {

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -185,12 +185,25 @@ class TestDates(QuestionTest):
         }) == {'example': '2017-03-19'}
 
 
-    def test_get_data_with_blank_year(self):
+    def test_get_data_with_blank_data(self):
+        assert self.question().get_data({
+            'example-day': '19',
+            'example-month': '03',
+        }) == {}
+
+        assert self.question().get_data({
+            'example-day': '19',
+            'example-month': '03',
+            'example-year': ' ',
+        }) == {}
+
         assert self.question().get_data({
             'example-day': '19',
             'example-month': '03',
             'example-year': '',
         }) == {}
+
+        assert self.question().get_data({}) == {}
 
 
 class TestBoolean(QuestionTest):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -687,11 +687,29 @@ class TestDateSummary(QuestionSummaryTest):
 
         return ContentQuestion(data)
 
-    def test_invalid_string(self):
+    def test_date_is_formatted_into_user_friendly_format(self):
+        question = self.question().summary({'example': '2016-02-18'})
+        assert question.value == '18 February 2016'
+
+    def test_not_a_date_format_falls_back_to_raw_string(self):
         non_date_string = 'not-a-date-formatted-string'
         question = self.question().summary({'example': non_date_string})
 
-        assert question.value == ''+non_date_string
+        assert question.value == non_date_string
+
+    def test_answer_not_required_if_non_empty_string_exists(self):
+        question = self.question().summary({'example': 'a string'})
+        assert not question.answer_required
+
+        question = self.question().summary({'example': '2016-02-18'})
+        assert not question.answer_required
+
+    def test_is_not_empty_if_not_empty_string_exists(self):
+        question = self.question().summary({'example': 'a string'})
+        assert not question.is_empty
+
+        question = self.question().summary({'example': '2016-02-18'})
+        assert not question.is_empty
 
 
 class TestTextSummary(QuestionSummaryTest):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -184,25 +184,13 @@ class TestDates(QuestionTest):
             'example-year': '2017',
         }) == {'example': '2017-03-19'}
 
-        # TODO confirm what behaviour should happen for the following cases
-        assert self.question().get_data({
-            'example-day': '19',
-            'example-month': '03',
-        }) == {}
 
-        assert self.question().get_data({
-            'example-day': '19',
-            'example-month': '03',
-            'example-year': ' ',
-        }) == {}
-
+    def test_get_data_with_blank_year(self):
         assert self.question().get_data({
             'example-day': '19',
             'example-month': '03',
             'example-year': '',
         }) == {}
-
-        assert self.question().get_data({}) == {}
 
 
 class TestBoolean(QuestionTest):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -221,14 +221,14 @@ class TestDates(QuestionTest):
         }) == {'example': None}
 
     def test_unformat_data(self):
-        assert self.question().unformat_data('example', '{'example': '2017-02-01'}) == {
+        assert self.question().unformat_data('example', {'example': '2017-02-01'}) == {
             'example-day': '01',
             'example-month': '02',
             'example-year': '2017',
         }
 
     def test_unformat_data_for_error(self):
-        assert self.question().unformat_data('example', '{'example': '2017-bb-01'}) == {
+        assert self.question().unformat_data('example', {'example': '2017-bb-01'}) == {
             'example-day': '01',
             'example-month': 'bb',
             'example-year': '2017',

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -197,13 +197,12 @@ class TestDates(QuestionTest):
             'example-year': ' ',
         }) == {}
 
+    def test_get_data_with_blank_year(self):
         assert self.question().get_data({
             'example-day': '19',
             'example-month': '03',
             'example-year': '',
         }) == {}
-
-        assert self.question().get_data({}) == {}
 
 
 class TestBoolean(QuestionTest):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -184,25 +184,27 @@ class TestDates(QuestionTest):
             'example-year': '2017',
         }) == {'example': '2017-03-19'}
 
-
     def test_get_data_with_blank_data(self):
         assert self.question().get_data({
             'example-day': '19',
             'example-month': '03',
-        }) == {}
+        }) == {'example': None}
 
         assert self.question().get_data({
             'example-day': '19',
             'example-month': '03',
             'example-year': ' ',
-        }) == {}
+        }) == {'example': None}
 
     def test_get_data_with_blank_year(self):
         assert self.question().get_data({
             'example-day': '19',
             'example-month': '03',
             'example-year': '',
-        }) == {}
+        }) == {'example': None}
+
+    def test_get_data_unknown_key(self):
+        assert self.question().get_data({'other': 'other value'}) == {'example': None}
 
 
 class TestBoolean(QuestionTest):
@@ -726,7 +728,7 @@ class TestDateSummary(QuestionSummaryTest):
 
     def test_date_is_formatted_into_user_friendly_format(self):
         question = self.question().summary({'example': '2016-02-18'})
-        assert question.value == '18 February 2016'
+        assert question.value == 'Thursday 18 February 2016'
 
     def test_not_a_date_format_falls_back_to_raw_string(self):
         non_date_string = 'not-a-date-formatted-string'

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -561,7 +561,6 @@ class TestDynamicListQuestion(QuestionTest):
             "yesno-0": True,
             "evidence-0": 'my evidence',
             "yesno-2": False,
-            "nonDynamicKey": 'data'
         }
 
         assert question.unformat_data(data) == expected

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -1,10 +1,11 @@
 # coding=utf-8
 from collections import OrderedDict
 
-import pytest
-
-from werkzeug.datastructures import OrderedMultiDict
 from markupsafe import Markup
+import pytest
+import six
+from werkzeug.datastructures import OrderedMultiDict
+
 from dmcontent.content_loader import ContentQuestion
 from dmcontent.utils import TemplateField
 from dmcontent import ContentTemplateError
@@ -790,7 +791,8 @@ class TestDateSummary(QuestionSummaryTest):
         assert not question.is_empty
 
     def test_date_before_1900(self):
-        old_date_string = '1899-01-01'
+
+        old_date_string = '1899-01-01' if six.PY2 else 'Sunday 1 January 1899'
         question = self.question().summary({'example': old_date_string})
 
         assert question.value == old_date_string

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -168,6 +168,43 @@ class TestText(QuestionTest):
         assert self.question().get_question_ids(type='text') == ['example']
 
 
+class TestDates(QuestionTest):
+    def question(self, **kwargs):
+        data = {
+            "id": "example",
+            "type": "date"
+        }
+        data.update(kwargs)
+        return ContentQuestion(data)
+
+    def test_get_data(self):
+        assert self.question().get_data({
+            'example-day': '19',
+            'example-month': '03',
+            'example-year': '2017',
+        }) == {'example': '2017-03-19'}
+
+        # TODO confirm what behaviour should happen for the following cases
+        assert self.question().get_data({
+            'example-day': '19',
+            'example-month': '03',
+        }) == {}
+
+        assert self.question().get_data({
+            'example-day': '19',
+            'example-month': '03',
+            'example-year': ' ',
+        }) == {}
+
+        assert self.question().get_data({
+            'example-day': '19',
+            'example-month': '03',
+            'example-year': '',
+        }) == {}
+
+        assert self.question().get_data({}) == {}
+
+
 class TestBoolean(QuestionTest):
     def question(self, **kwargs):
         data = {

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -213,7 +213,7 @@ class TestDates(QuestionTest):
             'example-year': '--',
         }) == {'example': '-03-19'}
 
-    def test_get_data_with_hyphens(self):
+    def test_get_data_with_all_hyphens(self):
         assert self.question().get_data({
             'example-day': '--',
             'example-month': '--',
@@ -240,6 +240,7 @@ class TestDates(QuestionTest):
     )
     def test_process_value(self, value, expected):
         assert self.question().process_value(value) == expected
+
 
 class TestBoolean(QuestionTest):
     def question(self, **kwargs):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -222,14 +222,14 @@ class TestDates(QuestionTest):
         }) == {'example': None}
 
     def test_unformat_data(self):
-        assert self.question().unformat_data('example', {'example': '2017-02-01'}) == {
+        assert self.question().unformat_data({'example': '2017-02-01'}) == {
             'example-day': '01',
             'example-month': '02',
             'example-year': '2017',
         }
 
     def test_unformat_data_for_error(self):
-        assert self.question().unformat_data('example', {'example': '2017-bb-01'}) == {
+        assert self.question().unformat_data({'example': '2017-bb-01'}) == {
             'example-day': '01',
             'example-month': 'bb',
             'example-year': '2017',
@@ -564,7 +564,7 @@ class TestDynamicListQuestion(QuestionTest):
             "nonDynamicKey": 'data'
         }
 
-        assert question.unformat_data('example', data) == expected
+        assert question.unformat_data(data) == expected
 
     def test_get_error_messages_unknown_key(self):
         question = self.question().filter(self.context())


### PR DESCRIPTION
## Create handlers for processing and displaying date questions.

* Create a new `Date` class for handling date questions.
* Create a new `DateSummary` class for handling viewing dates in summary tables etc.
* Register `Date` handler in `QUESTION_TYPES` to make it auto used by all date type questions.
* Tests.

https://trello.com/c/G3J4fbtw/30-add-question-type-to-content-loader-and-summary-display