### PR TITLE
BUGFIX-failing-YAML-test

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '3.6.0'
+__version__ = '3.6.1'

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1699,11 +1699,11 @@ class TestContentSection(object):
 
 
 class TestReadYaml(object):
-    @mock.patch.object(builtins, 'open', return_value=io.StringIO(u'foo: bar'))
+    @mock.patch('dmcontent.content_loader.open', return_value=io.StringIO(u'foo: bar'))
     def test_loading_existant_file(self, mocked_open):
         assert read_yaml('anything.yml') == {'foo': 'bar'}
 
-    @mock.patch.object(builtins, 'open', side_effect=IOError)
+    @mock.patch('dmcontent.content_loader.open', side_effect=IOError)
     def test_file_not_found(self, mocked_open):
         with pytest.raises(IOError):
             assert read_yaml('something.yml')


### PR DESCRIPTION
`tests/test_content_loader.py::TestReadYaml::test_loading_existant_file`
The above was failing on master when utils was added as a dependency, there's been a refactor recently but not sure what caused it tbh.

Fixed mock to point at instance open that is used by the function being
tested.

### Compatibility fix for upcoming adding new dmutils version


### To reproduce

```
git clone https://github.com/alphagov/digitalmarketplace-content-loader.git
cd digitalmarketplace-content-loader
vitrualenv venv
source venv/bin/activate
echo -e '\ngit+https://github.com/alphagov/digitalmarketplace-utils.git@25.0.1#egg=digitalmarketplace-utils==25.0.1' >> requirements.txt
pip install -r requirements_for_test.txt
py.test
```