### PR TITLE
Fix missing dm-utils dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 -e .
+# DON'T FORGET TO UPDATE setup.py !!
 git+https://github.com/alphagov/digitalmarketplace-utils.git@25.1.0#egg=digitalmarketplace-utils==25.1.0

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
         'Werkzeug==0.11.9',
         'inflection==0.3.1',
         'six==1.10.0',
-        'digitalmarketplace-utils>=25.0.1',
+        'digitalmarketplace-utils>=25.1.0',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'PyYAML==3.11',
         'Werkzeug==0.11.9',
         'inflection==0.3.1',
-        'six==1.10.0'
+        'six==1.10.0',
+        'digitalmarketplace-utils>=25.0.1',
     ]
 )


### PR DESCRIPTION
Add dm-utils dependency to setup.py, as well as requirements.txt:

 - required so that apps dependent on the Content Loader fail clearly if they do not already have dm-utils in _their_ requirements.txt.