### PR TITLE
Content loader for service page

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '4.2.0'
+__version__ = '4.3.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -353,6 +353,10 @@ class ContentSection(object):
 
         return errors_map
 
+    @property
+    def is_empty(self):
+        return all(question.is_empty for question in self.questions)
+
     @staticmethod
     def unformat_assurance(key, data):
         return {

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -145,6 +145,27 @@ class TestFilterContentSection(object):
         assert copied_section.prefill is False
         assert copied_section.editable is False
 
+    def test_is_empty(self):
+        questions = [
+            Question({'id': 'q1', 'name': 'q1', 'type': 'unknown'}),
+            Question({'id': 'q2', 'name': 'q2', 'type': 'unknown'})
+            ]  # note that id and type are required as this function indirectly calls QuestionSummary.value
+
+        section = ContentSection(
+            slug='section',
+            name=TemplateField('Section'),
+            prefill=False,
+            editable=False,
+            edit_questions=False,
+            questions=questions
+        )
+        answered = section.summary({'q1': 'a1', 'q2': 'a2'})
+        assert not answered.is_empty
+        half_answered = section.summary({'q1': 'a1', 'q2': ''})
+        assert not half_answered.is_empty
+        not_answered = section.summary({'q1': '', 'q2': ''})
+        assert not_answered.is_empty
+
     def test_getting_a_multiquestion_as_a_section_preserves_value_of_context_attribute(self):
         multiquestion_data = {
             "id": "example",


### PR DESCRIPTION
Provide easy way to determine if an entire section is empty
 - Empty sections shouldn't show on the service page for buyers
 - An empty section is any section where none of the answers have been
   filled out.

https://trello.com/c/9mmLtRCC/352-questions-with-dependencies