### PR TITLE
Make validation messages into TemplateFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ These are the fields that are turned into TemplateFields when the YAML files are
 
 | ContentSection                    | Question                                           |
 |-----------------------------------|----------------------------------------------------|
-| [`name`, `description`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/content_loader.py#L123) | [`question`, `name`, `question_advice`, `hint`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/questions.py#L10) |
+| [`name`, `description`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/content_loader.py#L123) | [`question`, `name`, `question_advice`, `hint`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/474d9adce0f422700cbf2dfc8815a7503ab368bc/dmcontent/questions.py#L10), and [`options[i].description`, and `validations[i].message`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/29b1be3571558312a4b6271c06d04b65b44dd607/dmcontent/questions.py#L14) <sub>since v4.4.2</sub> |
 
 In addition, all string fields (including fields in lists and nested dictionaries) in content
 messages are turned into TemplateFields.

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '4.4.1'
+__version__ = '4.4.2'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -520,12 +520,16 @@ class ContentLoader(object):
             if field in question_data:
                 question_data[field] = TemplateField(question_data[field])
 
-        # We also want to support TemplateFields as subfields of entries in options (e.g. for lot descriptions)
-        for subfield in Question.TEMPLATE_OPTIONS_FIELDS:
-            if 'options' in question_data:
-                for i, option in enumerate(question_data['options']):
+        """
+        We want to support TemplateFields as keys of list items, for example:
+        - {options: [{description: '{{ "jinja" }}'}]} in the lot question
+        - {validations: [{message: '{{ "jinja" }}'}]} in some declaration questions
+        """
+        for field, subfield in Question.TEMPLATE_OPTIONS_FIELDS:
+            if field in question_data:
+                for i, option in enumerate(question_data[field]):
                     if subfield in option:
-                        question_data['options'][i][subfield] = TemplateField(question_data['options'][i][subfield])
+                        question_data[field][i][subfield] = TemplateField(question_data[field][i][subfield])
 
         self._questions[framework_slug][question_set][question] = question_data
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -11,7 +11,7 @@ from .utils import TemplateField, drop_followups, get_option_value
 
 class Question(object):
     TEMPLATE_FIELDS = ['name', 'question', 'hint', 'question_advice']
-    TEMPLATE_OPTIONS_FIELDS = ['description']
+    TEMPLATE_OPTIONS_FIELDS = [('options', 'description'), ('validations', 'message')]
 
     def __init__(self, data, number=None, _context=None):
         self.number = number
@@ -202,7 +202,7 @@ class Question(object):
 
         if isinstance(field, TemplateField):
             return field.render(self._context)
-        elif key == 'options':
+        elif key in [_field for _field, _ in self.TEMPLATE_OPTIONS_FIELDS]:
             return [{k: (v.render(self._context) if isinstance(v, TemplateField) else v)
                      for k, v in i.items()
                      }

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1831,7 +1831,23 @@ class TestContentLoader(object):
             "question": "Question one",
             "question_advice": "This is the first question",
             "hint": "100 character limit",
-            "type": "text",
+            "type": "radios",
+            "options": [
+                {
+                    "value": "Option 1",
+                    "description": "This is the first option"
+                }, {
+                    "value": "Option 2",
+                    "description": "This is the second option"
+                },
+            ],
+            "validations": [
+                {
+                    "name": "answer_required",
+                    "message": "You have to answer the question"
+                }
+            ]
+
         }
 
         yaml_loader = ContentLoader('content/')
@@ -1843,7 +1859,14 @@ class TestContentLoader(object):
             "question": TemplateField("Question one"),
             "question_advice": TemplateField("This is the first question"),
             "hint": TemplateField("100 character limit"),
-            "type": "text",
+            "type": "radios",
+            "options": [
+                {"value": "Option 1", "description": TemplateField("This is the first option")},
+                {"value": "Option 2", "description": TemplateField("This is the second option")}
+            ],
+            "validations": [
+                {"name": "answer_required", "message": TemplateField("You have to answer the question")}
+            ]
         }
         read_yaml_mock.assert_called_with(
             'content/frameworks/framework-slug/questions/question-set/question1.yml')

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -111,17 +111,16 @@ class QuestionTest(object):
         assert question.question == "Question"
 
     def test_question_options_descriptions_render_template_fields(self):
-        """If the question has an options field, check that all TEMPLATE_OPTIONS_FIELDS are correctly rendered from
+        """Check that all TEMPLATE_OPTIONS_FIELDS fields are correctly rendered from
         TemplateFields by passing in markup and ensuring they turn into Markup objects.
         Does not recurse through options.options.[...] fields, e.g. for CheckboxTree"""
         question = self.question()
 
-        if hasattr(question, 'options'):
-            options = question['options']
-            for subfield in question.TEMPLATE_OPTIONS_FIELDS:
-                for option in options:
-                    if subfield in option:
-                        assert type(option[subfield]) == Markup
+        for field, subfield in question.TEMPLATE_OPTIONS_FIELDS:
+            if hasattr(question, field):
+                for item in question[field]:
+                    if subfield in item:
+                        assert type(item[subfield]) == Markup
 
 
 class TestText(QuestionTest):
@@ -621,6 +620,9 @@ class TestCheckboxes(QuestionTest):
                                                                                         " [markup](links)")},
                 {"label": "Option label", "value": "value1"},
                 {"label": "Wrong label", "value": "value2"},
+            ],
+            "validations": [
+                {"name": "answer_required", "message": TemplateField("You have to answer the question")}
             ]
         }
         data.update(kwargs)
@@ -659,6 +661,9 @@ class TestRadios(TestCheckboxes):
                                                                                         " [markup](links)")},
                 {"label": "Option label", "value": "value1"},
                 {"label": "Wrong label", "value": "value2"},
+            ],
+            "validations": [
+                {"name": "answer_required", "message": TemplateField("You have to answer the question")}
             ]
         }
         data.update(kwargs)


### PR DESCRIPTION
Some of our declaration questions want to be able to reference other questions, so that we can say things like 
```if you answered question 32, you have to answer this one```. 

The syntax they use for this is a bit peculiar. It looks like 
```if you answered question [[questionId]], you have to answer this one```.

I'm trying to get rid of this, in favour of something like
```if you answered question {{ content.get_question('questionId').number }}, you have to answer this one.```


Since v2 of the Content Loader, we can [use jinja to render `TemplateField`s](https://github.com/alphagov/digitalmarketplace-content-loader/blob/master/CHANGELOG.md#200).  The fields we allow to be templated are whitelisted -- for example, `question` and `hint` accept jinja templating, but `type` and `id` don't.  

Some of the values we want to replace in the declaration questions are in validation messages (ie, [mitigatingFactors2.yml](https://github.com/alphagov/digitalmarketplace-frameworks/blob/fe77c4134ad56c5847807b5ddc1c73046d60a3d2/frameworks/digital-outcomes-and-specialists-2/questions/declaration/mitigatingFactors2.yml#L7)) but validation messages aren't whitelisted as `TemplateField`s.

This pull request makes the `message` value of `validation` items into `TemplateField`s.

***

**Note**

If this pull request goes in, there's a couple of other things to follow up with:
- updating the README in the frameworks repo with all `TemplateField`s (ie, [like this](https://github.com/alphagov/digitalmarketplace-frameworks/tree/pc-update-readme-with-more-template-fields))
- removing the `question_references` stuff entirely in the supplier app (ie, [more or less like this](https://github.com/alphagov/digitalmarketplace-supplier-frontend/tree/pc-kill-the-double-square-brackets))