### PR TITLE
Add ability to set pricing question decimal place restriction

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '4.5.0'
+__version__ = '4.6.0'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -459,6 +459,7 @@ class Pricing(Question):
     def __init__(self, data, *args, **kwargs):
         super(Pricing, self).__init__(data, *args, **kwargs)
         self.fields = data['fields']
+        self.decimal_place_restriction = data.get('decimal_place_restriction', False)
 
     def summary(self, service_data):
         return PricingSummary(self, service_data)

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict, defaultdict
 from datetime import datetime
+import re
 
 from dmutils.formats import DATE_FORMAT, DISPLAY_DATE_FORMAT
 
@@ -459,6 +460,8 @@ class Pricing(Question):
     def __init__(self, data, *args, **kwargs):
         super(Pricing, self).__init__(data, *args, **kwargs)
         self.fields = data['fields']
+
+        # True if we are restricting to an integer or a 2dp value (representing pounds and optionally pence)
         self.decimal_place_restriction = data.get('decimal_place_restriction', False)
 
     def summary(self, service_data):
@@ -478,7 +481,21 @@ class Pricing(Question):
         this question (therefore only those pairs relevant to this question).
         Filter 0/ False values here and replace with None as they are handled with the optional flag.
         """
-        return {key: form_data[key] or None for key in self.fields.values() if key in form_data}
+        question_data = {key: form_data[key] or None for key in self.fields.values() if key in form_data}
+
+        if self.decimal_place_restriction:
+            # Permissive validation to transform incomplete pennies to 2dp
+            pattern_0dp = re.compile(r"\d+(\.)$")  # integer followed by '.' but no decimal values
+            pattern_1dp = re.compile(r"\d+(\.)(?:\d)$")  # integer with 1 decimal place
+            for key, value in question_data.items():
+                if value:
+                    if pattern_0dp.search(value):
+                        question_data[key] = value + "00"
+
+                    if pattern_1dp.search(value):
+                        question_data[key] = value + "0"
+
+        return question_data
 
     @property
     def form_fields(self):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -301,6 +301,12 @@ class TestPricing(QuestionTest):
     def test_get_question_ids_by_type(self):
         assert self.question().get_question_ids(type='pricing') == ['example']
 
+    def test_pricing_question_decimal_place_restriction_is_false_by_default(self):
+        assert self.question().decimal_place_restriction is False
+
+    def test_pricing_question_decimal_place_restriction_can_be_set_true(self):
+        assert self.question(decimal_place_restriction=True).decimal_place_restriction is True
+
 
 class TestMultiquestion(QuestionTest):
     def question(self, **kwargs):


### PR DESCRIPTION
https://trello.com/c/PHnolEgP/16-change-money-format-on-awarding-a-brief-to-be-pounds-and-pence

Users had previously been able to say that a contract was worth £8.105. This should not be allowed. Instead we only allow 0 or 2 decimal places e.g £8 or £8.10 to be stored in the database. This new content loader property can be used by the frameworks repo to know when to use the stricter format for `pricing` questions and generate the new JSON schemas for them.

In addition, we make the validation permissive so if a user enters '10.0' or '10.', it will be transformed into '10.00' and their price will validate rather then forcing them to type their answer in the exact format we require. 

![permissive2](https://user-images.githubusercontent.com/7228605/31780917-fd37ffc0-b4ee-11e7-9cf0-e256e2d087ed.gif)


See frameworks repo PR for further details - https://github.com/alphagov/digitalmarketplace-frameworks/pull/477