### PR TITLE
Upgrade DM utils dependency

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '4.6.0'
+__version__ = '4.7.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -e .
 # DON'T FORGET TO UPDATE setup.py !!
-git+https://github.com/alphagov/digitalmarketplace-utils.git@25.1.0#egg=digitalmarketplace-utils==25.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@30.0.0#egg=digitalmarketplace-utils==30.0.0

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
         'Werkzeug==0.11.9',
         'inflection==0.3.1',
         'six==1.10.0',
-        'digitalmarketplace-utils>=25.1.0',
+        'digitalmarketplace-utils>=30.0.0',
     ]
 )


### PR DESCRIPTION
The content loader repo currently requires v.25.1.0 of the `digitalmarketplace-utils` library. This version has an outdated dependency on `cryptography` package that is not compatible with Python3, meaning we are unable to build an environment or run tests against the content loader.

This PR bumps the DM utils dependency to v30.0.0. That's 5 major versions, but I'm confident that this shouldn't introduce breaking changes. The content loader only uses `dmutils` in two places: date formatting and the `DMSandboxedEnvironment`, neither of which have changed since v25.1.0. 

Please let me know if I've missed anything that means this upgrade should be 5.0.0 instead of 4.7.0!