### PR TITLE
Fix pytest warnings

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '4.7.0'
+__version__ = '4.7.1'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ flake8==2.6.2
 flake8-putty==0.4.0
 mock==2.0.0
 pytest==3.2.3
-pytest-cov==2.2.0
+pytest-cov==2.5.1
 python-coveralls==2.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 norecursedirs = venv*

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -3,54 +3,35 @@ from dmcontent.formats import format_price, format_service_price
 import pytest
 
 
-def test_format_price():
-    cases = [
-        ((u'12', None, 'Unit', None), u'£12 per unit'),
-        (('12', '13', 'Unit', None), u'£12 to £13 per unit'),
-        (('12', '13', 'Unit', 'Second'), u'£12 to £13 per unit per second'),
-        (('12', None, 'Unit', 'Second'), u'£12 per unit per second'),
-        ((12, 13, 'Unit', None), u'£12 to £13 per unit'),
-        (('34', None, 'Lab', None, '4 hours'), u'4 hours for £34'),
-        (('12', None, None, None), u'£12'),
-    ]
-
-    def check_price_formatting(args, formatted_price):
-        assert format_price(*args) == formatted_price
-
-    for args, formatted_price in cases:
-        yield check_price_formatting, args, formatted_price
+@pytest.mark.parametrize('args, formatted_price', [
+    ((u'12', None, 'Unit', None), u'£12 per unit'),
+    (('12', '13', 'Unit', None), u'£12 to £13 per unit'),
+    (('12', '13', 'Unit', 'Second'), u'£12 to £13 per unit per second'),
+    (('12', None, 'Unit', 'Second'), u'£12 per unit per second'),
+    ((12, 13, 'Unit', None), u'£12 to £13 per unit'),
+    (('34', None, 'Lab', None, '4 hours'), u'4 hours for £34'),
+    (('12', None, None, None), u'£12'),
+])
+def test_format_price(args, formatted_price):
+    assert format_price(*args) == formatted_price
 
 
 def test_format_price_errors():
-    cases = [
-        (None, None, None, None),
-    ]
-
-    def check_price_formatting(case):
-        with pytest.raises((TypeError, AttributeError)):
-            format_price(*case)
-
-    for case in cases:
-        yield check_price_formatting, case
+    with pytest.raises((TypeError, AttributeError)):
+        format_price(*(None, None, None, None))
 
 
-def test_format_service_price():
+@pytest.mark.parametrize('price_min, formatted_price', [
+    ('12.12', u'£12.12 to £13.13 per unit per second'),
+    ('', ''),
+    (None, ''),
+])
+def test_format_service_price(price_min, formatted_price):
     service = {
-        'priceMin': '12.12',
+        'priceMin': price_min,
         'priceMax': '13.13',
         'priceUnit': 'Unit',
         'priceInterval': 'Second',
     }
 
-    cases = [
-        ('12.12', u'£12.12 to £13.13 per unit per second'),
-        ('', ''),
-        (None, ''),
-    ]
-
-    def check_service_price_formatting(price_min, formatted_price):
-        service['priceMin'] = price_min
-        assert format_service_price(service) == formatted_price
-
-    for price_min, formatted_price in cases:
-        yield check_service_price_formatting, price_min, formatted_price
+    assert format_service_price(service) == formatted_price


### PR DESCRIPTION
Good news: Following the upgrade of the content loader (https://github.com/alphagov/digitalmarketplace-content-loader/pull/49), we can now run tests. 

Bad news: there are some pytest deprecation warnings. This PR fixes them.