### PR TITLE
Add 'try_load_manifest' generic method for apps.

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '4.8.0'
+__version__ = '4.9.0'

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -5,6 +5,7 @@ from markdown import markdown
 from six import string_types
 
 from dmutils.jinja2_environment import DMSandboxedEnvironment
+from dmcontent.errors import ContentNotFoundError
 
 from .errors import ContentTemplateError
 
@@ -98,3 +99,13 @@ def get_option_value(option):
     :return: string value to be persisted
     """
     return option.get('value') or option['label']
+
+
+def try_load_manifest(content_loader, application, data, question_set, manifest):
+    try:
+        content_loader.load_manifest(data['slug'], question_set, manifest)
+
+    except ContentNotFoundError:
+        application.logger.info(
+            "Could not load {}.{} manifest for {}".format(question_set, manifest, data['slug'])
+        )


### PR DESCRIPTION
## Summary
Add a util method to try loading a manifest in an application. The tests might be controversial as they literally just check what the method is doing internally, but that feels like the right thing to do in this case I think the contract this method makes is simply that another method is called - what that method itself does shouldn't be tested here, I don't think.

Bump version to 4.9.0

## Related PR
https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/68

## Ticket
https://trello.com/c/tnBdllTV/156-briefs-frontend-has-crashed-on-preview-wont-come-back-up