### PR TITLE
Straw man for moving question references into the content loader

### DIFF
--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -35,8 +35,32 @@ class ContentManifest(object):
                 question_index += 1
                 question.number = question_index
 
+        for section in self.sections:
+            for question in section.questions:
+                if question.get("hint"):
+                    question._data["hint"] = self.question_references(question["hint"])
+
+
     def __iter__(self):
         return self.sections.__iter__()
+
+    def question_references(self, data):
+        """
+        Replace placeholders for question references with the number of the referenced question
+        e.g. "This is my question hint which references question [[anotherQuestion]]" becomes
+        "This is my question hint which references question 7"
+        :param data: Object to have placeholders replaced for example a string or Markup object
+        :return: Object with same type of original `data` object but with question references replaced
+        """
+        if not data:
+            return data
+        references = re.sub(
+            r"\[\[([^\]]+)\]\]",  # anything that looks like [[nameOfQuestion]]
+            lambda question_id: str(self.get_question(question_id.group(1))['number']),
+            data
+        )
+
+        return data.__class__(references)
 
     def summary(self, service_data):
         """Create a manifest instance for service summary display

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1721,13 +1721,13 @@ class TestContentLoader(object):
         ]
 
     def question1(self):
-        return {"name": "question1", "depends": [{"on": "lot", "being": "SaaS"}]}
+        return {"name": "question1", "hint": "References q [[q2]]", "depends": [{"on": "lot", "being": "SaaS"}]}
 
     def question2(self):
         return {"id": "q2", "name": "question2", "depends": [{"on": "lot", "being": "SaaS"}]}
 
     def question3(self):
-        return {"name": "question3", "depends": [{"on": "lot", "being": "IaaS"}]}
+        return {"name": "question3", "hint": "References q [[question1]]", "depends": [{"on": "lot", "being": "IaaS"}]}
 
     def test_manifest_loading(self, read_yaml_mock):
         self.set_read_yaml_mock_response(read_yaml_mock)
@@ -2068,6 +2068,18 @@ class TestContentLoader(object):
         with pytest.raises(ContentNotFoundError):
             yaml_loader = ContentLoader('content/')
             yaml_loader.get_manifest('framework-slug', 'manifest')
+
+    def test_foo(self, read_yaml_mock):
+        self.set_read_yaml_mock_response(read_yaml_mock)
+
+        yaml_loader = ContentLoader('content/')
+        yaml_loader.load_manifest('framework-slug', 'question-set', 'my-manifest')
+        manifest = yaml_loader.get_manifest('framework-slug', 'my-manifest')
+        q1hint = manifest.sections[0]["questions"][0]["hint"]
+        assert q1hint == 'References q 2'
+
+        q3hint = manifest.sections[1]["questions"][0]["hint"]
+        assert q3hint == 'References q 1'
 
 
 @pytest.mark.parametrize("title,slug", [


### PR DESCRIPTION
STRAWMAN

Appears to work in principle so we would no longer need this
in the template layer.

Few issues that I haven't looked at yet include
- setting question data properties without using private properties
- Template fields (making sure this doesn't screw things up)
- How to decide which fields to run question referencing through
- How to potentially make this behaviour optional
- Proper tests etc
- The other tests that I've broken