### PR TITLE
Load arbitrary framework metadata

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '4.9.0'
+__version__ = '4.10.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -463,6 +463,9 @@ class ContentLoader(object):
     >>>
     >>> # get a message
     >>> loader.get_message('framework-1', 'homepage_sidebar', 'in_review')
+    >>>
+    >>> # get some metadata
+    >>> loader.get_message('framework-1', 'copy_services', 'source_framework')
 
     """
     def __init__(self, content_path):

--- a/dmcontent/metadata.py
+++ b/dmcontent/metadata.py
@@ -1,4 +1,4 @@
-class ContentMetadata(object):
+class ContentMetadata:
     """
     A simple reader for framework-related static data. This class performs a similar function to a ContentMessage,
     except it does not parse or render any of the data passed in, so templated messages are not supported.

--- a/dmcontent/metadata.py
+++ b/dmcontent/metadata.py
@@ -1,0 +1,40 @@
+class ContentMetadata(object):
+    """
+    A simple reader for framework-related static data. This class performs a similar function to a ContentMessage,
+    except it does not parse or render any of the data passed in, so templated messages are not supported.
+    """
+    def __init__(self, data):
+        self._data = data.copy()
+
+    def get(self, key, default=None):
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            return default
+
+    def __eq__(self, other):
+        if not isinstance(other, ContentMetadata):
+            return False
+        return self._data == other._data
+
+    def __getattr__(self, key):
+        try:
+            field = self._data[key]
+        except KeyError:
+            raise AttributeError(key)
+
+        return self._render(field)
+
+    def _render(self, field):
+        if isinstance(field, dict):
+            return ContentMetadata(field)
+        elif isinstance(field, list):
+            return [self._render(i) for i in field]
+        else:
+            return field
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __repr__(self):
+        return '<{0.__class__.__name__}: data={0._data}>'.format(self)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'Jinja2==2.8',
+        'Jinja2==2.10',
         'Markdown==2.6.7',
         'PyYAML==3.11',
         'Werkzeug==0.11.9',

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -8,7 +8,7 @@ import io
 
 from dmcontent.utils import TemplateField
 from dmcontent.content_loader import (
-    ContentLoader, ContentSection, ContentManifest, ContentMessage,
+    ContentLoader, ContentSection, ContentManifest, ContentMessage, ContentMetadata,
     read_yaml, ContentNotFoundError, QuestionNotFoundError, _make_slug
 )
 
@@ -1978,7 +1978,6 @@ class TestContentLoader(object):
         assert messages.get_message('g-cloud-7', 'index', 'field_one') == 'value_one'
 
     def test_load_message_wraps_nested_fields_with_template_field(self, mock_read_yaml):
-
         mock_read_yaml.return_value = {
             'coming': {
                 'heading': 'G-Cloud 7 is coming',
@@ -2006,7 +2005,6 @@ class TestContentLoader(object):
         assert messages.get_message('g-cloud-7', 'index').coming.messages[0] == 'Get ready'
 
     def test_load_message_argument_types(self, mock_read_yaml):
-
         mock_read_yaml.return_value = {}
         messages = ContentLoader('content/')
 
@@ -2014,7 +2012,6 @@ class TestContentLoader(object):
             messages.load_messages('g-cloud-7', 'index')  # blocks argument must be a list
 
     def test_get_message_must_preload(self, mock_read_yaml):
-
         mock_read_yaml.return_value = {}
         messages = ContentLoader('content/')
         messages.load_messages('g-cloud-8', ['index'])
@@ -2024,7 +2021,6 @@ class TestContentLoader(object):
             mock_read_yaml.assert_not_called()
 
     def test_caching_of_messages(self, mock_read_yaml):
-
         messages = ContentLoader('content/')
         messages.load_messages('g-cloud-7', ['index'])
         messages.get_message('g-cloud-7', 'index').get('coming')
@@ -2033,12 +2029,82 @@ class TestContentLoader(object):
         mock_read_yaml.assert_called_once_with('content/frameworks/g-cloud-7/messages/index.yml')
 
     def test_load_message_raises(self, mock_read_yaml):
-
         mock_read_yaml.side_effect = IOError
         messages = ContentLoader('content/')
 
         with pytest.raises(ContentNotFoundError):
             messages.load_messages('not-a-framework', ['index'])
+
+    def test_get_metadata(self, mock_read_yaml):
+        mock_read_yaml.return_value = {
+            'field_one': 'value_one',
+            'field_two': 'value_two',
+        }
+        metadata = ContentLoader('content/')
+        metadata.load_metadata('g-cloud-7', ['index'])
+
+        assert metadata.get_metadata('g-cloud-7', 'index') == ContentMetadata({
+            'field_one': 'value_one',
+            'field_two': 'value_two',
+        })
+
+        assert metadata.get_metadata('g-cloud-7', 'index').field_one == 'value_one'
+
+    def test_get_metadata_with_key(self, mock_read_yaml):
+        mock_read_yaml.return_value = {
+            'field_one': 'value_one',
+            'field_two': 'value_two',
+        }
+        metadata = ContentLoader('content/')
+        metadata.load_metadata('g-cloud-7', ['index'])
+
+        assert metadata.get_metadata('g-cloud-7', 'index', 'field_one') == 'value_one'
+
+    def test_load_metadata_wraps_nested_fields_with_template_field(self, mock_read_yaml):
+        mock_read_yaml.return_value = {
+            'source_framework': 'g-cloud-6',
+            'questions_to_copy': ['question-1', 'question-2']
+        }
+        metadata = ContentLoader('content/')
+        metadata.load_metadata('g-cloud-7', ['copy_services'])
+
+        assert metadata.get_metadata('g-cloud-7', 'copy_services') == ContentMetadata({
+            'source_framework': 'g-cloud-6',
+            'questions_to_copy': ['question-1', 'question-2']
+        })
+
+        assert metadata.get_metadata('g-cloud-7', 'copy_services').source_framework == 'g-cloud-6'
+
+    def test_load_metadata_argument_types(self, mock_read_yaml):
+        mock_read_yaml.return_value = {}
+        metadata = ContentLoader('content/')
+
+        with pytest.raises(TypeError):
+            metadata.load_metadata('g-cloud-7', 'index')  # blocks argument must be a list
+
+    def test_get_metadata_must_preload(self, mock_read_yaml):
+        mock_read_yaml.return_value = {}
+        metadata = ContentLoader('content/')
+        metadata.load_metadata('g-cloud-8', ['index'])
+
+        with pytest.raises(ContentNotFoundError):
+            metadata.get_metadata('g-cloud-8', 'copy_services')
+            mock_read_yaml.assert_not_called()
+
+    def test_caching_of_metadata(self, mock_read_yaml):
+        metadata = ContentLoader('content/')
+        metadata.load_metadata('g-cloud-7', ['copy_services'])
+        metadata.get_metadata('g-cloud-7', 'copy_services').get('source_framework')
+        metadata.get_metadata('g-cloud-7', 'copy_services').get('source_framework')
+
+        mock_read_yaml.assert_called_once_with('content/frameworks/g-cloud-7/metadata/copy_services.yml')
+
+    def test_load_metadata_raises(self, mock_read_yaml):
+        mock_read_yaml.side_effect = IOError
+        metadata = ContentLoader('content/')
+
+        with pytest.raises(ContentNotFoundError):
+            metadata.load_metadata('not-a-framework', ['index'])
 
     def test_get_manifest(self, read_yaml_mock):
         self.set_read_yaml_mock_response(read_yaml_mock)

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -2008,25 +2008,18 @@ class TestContentLoader(object):
         mock_read_yaml.return_value = {}
         messages = ContentLoader('content/')
 
-        with pytest.raises(TypeError):
-            messages.load_messages('g-cloud-7', 'index')  # blocks argument must be a list
+        with pytest.raises(TypeError) as err:
+            messages.load_messages('g-cloud-7', 'index')
+
+        assert str(err.value) == 'Content blocks must be a list'
 
     def test_get_message_must_preload(self, mock_read_yaml):
         mock_read_yaml.return_value = {}
         messages = ContentLoader('content/')
-        messages.load_messages('g-cloud-8', ['index'])
 
         with pytest.raises(ContentNotFoundError):
             messages.get_message('g-cloud-8', 'dashboard')
             mock_read_yaml.assert_not_called()
-
-    def test_caching_of_messages(self, mock_read_yaml):
-        messages = ContentLoader('content/')
-        messages.load_messages('g-cloud-7', ['index'])
-        messages.get_message('g-cloud-7', 'index').get('coming')
-        messages.get_message('g-cloud-7', 'index').get('coming')
-
-        mock_read_yaml.assert_called_once_with('content/frameworks/g-cloud-7/messages/index.yml')
 
     def test_load_message_raises(self, mock_read_yaml):
         mock_read_yaml.side_effect = IOError
@@ -2060,7 +2053,9 @@ class TestContentLoader(object):
 
         assert metadata.get_metadata('g-cloud-7', 'index', 'field_one') == 'value_one'
 
-    def test_load_metadata_wraps_nested_fields_with_template_field(self, mock_read_yaml):
+    def test_load_metadata_does_not_mutate_values(self, mock_read_yaml):
+        """When values are loaded into a ContentMessage, they are all wrapped as TemplateFieds. We want to make sure
+        that nothing wraps the values for ContentMetadata as it is only static content."""
         mock_read_yaml.return_value = {
             'source_framework': 'g-cloud-6',
             'questions_to_copy': ['question-1', 'question-2']
@@ -2079,25 +2074,18 @@ class TestContentLoader(object):
         mock_read_yaml.return_value = {}
         metadata = ContentLoader('content/')
 
-        with pytest.raises(TypeError):
-            metadata.load_metadata('g-cloud-7', 'index')  # blocks argument must be a list
+        with pytest.raises(TypeError) as err:
+            metadata.load_metadata('g-cloud-7', 'index')
+
+        assert str(err.value) == 'Content blocks must be a list'
 
     def test_get_metadata_must_preload(self, mock_read_yaml):
         mock_read_yaml.return_value = {}
         metadata = ContentLoader('content/')
-        metadata.load_metadata('g-cloud-8', ['index'])
 
         with pytest.raises(ContentNotFoundError):
             metadata.get_metadata('g-cloud-8', 'copy_services')
             mock_read_yaml.assert_not_called()
-
-    def test_caching_of_metadata(self, mock_read_yaml):
-        metadata = ContentLoader('content/')
-        metadata.load_metadata('g-cloud-7', ['copy_services'])
-        metadata.get_metadata('g-cloud-7', 'copy_services').get('source_framework')
-        metadata.get_metadata('g-cloud-7', 'copy_services').get('source_framework')
-
-        mock_read_yaml.assert_called_once_with('content/frameworks/g-cloud-7/metadata/copy_services.yml')
 
     def test_load_metadata_raises(self, mock_read_yaml):
         mock_read_yaml.side_effect = IOError

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,46 @@
+from dmcontent.metadata import ContentMetadata
+from dmcontent.utils import TemplateField
+
+
+class TestContentMetadata(object):
+    def test_content_metadata_field(self):
+        metadata = ContentMetadata({'name': "Name"})
+
+        assert metadata.name == 'Name'
+
+    def test_get_missing_field(self):
+        metadata = ContentMetadata({})
+
+        assert metadata.get('key', 'default') == 'default'
+
+    def test_metadata_eq(self):
+        metadata = ContentMetadata({"name": "value"})
+
+        assert metadata == ContentMetadata({"name": "value"})
+        assert metadata != {"name": "value"}
+
+    def test_metadata_get_item(self):
+        metadata = ContentMetadata({"name": "value"})
+
+        assert metadata['name'] == 'value'
+
+    def test_metadata_repr(self):
+        metadata = ContentMetadata({"name": "value"})
+
+        assert metadata.__repr__() == "<ContentMetadata: data={'name': 'value'}>"
+
+    def test_content_metadata_does_not_render_template_fields(self):
+        metadata = ContentMetadata({'name': TemplateField("Field {{ name }}")})
+
+        assert metadata.name == TemplateField('Field {{ name }}')
+
+    def test_content_metadata_dict_field_returns_content_metadata(self):
+        metadata = ContentMetadata({'nested': {'name': 'Name'}})
+
+        assert isinstance(metadata.nested, ContentMetadata)
+        assert metadata.nested.name == 'Name'
+
+    def test_content_metadata_list_field_does_not_render_template_fields(self):
+        metadata = ContentMetadata({'nested': [TemplateField('Name'), TemplateField('{{ name }}')]})
+
+        assert metadata.nested == [TemplateField('Name'), TemplateField('{{ name }}')]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,12 +1,20 @@
+import pytest
+
 from dmcontent.metadata import ContentMetadata
 from dmcontent.utils import TemplateField
 
 
 class TestContentMetadata(object):
-    def test_content_metadata_field(self):
+    def test_content_metadata_getattr(self):
         metadata = ContentMetadata({'name': "Name"})
 
         assert metadata.name == 'Name'
+
+    def test_content_metadata_getattr_raises_attribute_error_if_missing(self):
+        metadata = ContentMetadata({'name': "Name"})
+
+        with pytest.raises(AttributeError):
+            assert metadata.foo == 'missing'
 
     def test_get_missing_field(self):
         metadata = ContentMetadata({})


### PR DESCRIPTION
 ## Summary
We need to be able to copy services from one framework to another during
applications to save suppliers time. In order to do this, we need to
define which previous framework has services that are eligible for
copying, and which questions are suitable. This information appears to
be data related to the framework, so we are storing it in dm-frameworks
as metadata about a given framework (in this case, G-Cloud 10). In order
for a frontend to have that information, we need to be able to load it.
The `messages` folder of dm-frameworks stores files that contain
key-value pairs, and this is the same kind of information format we want
for our metadata, so this creates a stripped-down version of the same
which works on the `metadata` folder of a framework. A ContentMetadata
instance does not parse the data it reads and therefore does not support
templated fields; this seems like a reasonable conclusion to make as we
are simply storing static data that describes how the framework
interacts with others.

## Related PR
https://github.com/alphagov/digitalmarketplace-frameworks/pull/515