### PR TITLE
Add util functions for trying to load metadata and messages

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '4.10.1'
+__version__ = '4.11.0'

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -109,3 +109,23 @@ def try_load_manifest(content_loader, application, data, question_set, manifest)
         application.logger.info(
             "Could not load {}.{} manifest for {}".format(question_set, manifest, data['slug'])
         )
+
+
+def try_load_metadata(content_loader, application, data, metadata):
+    try:
+        content_loader.load_metadata(data['slug'], metadata)
+
+    except ContentNotFoundError:
+        application.logger.info(
+            "Could not load '{}' metadata for {}".format(metadata, data['slug'])
+        )
+
+
+def try_load_messages(content_loader, application, data, messages):
+    try:
+        content_loader.load_messages(data['slug'], messages)
+
+    except ContentNotFoundError:
+        application.logger.info(
+            "Could not load '{}' messages for {}".format(messages, data['slug'])
+        )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
+        'Flask==0.10.1',
         'Jinja2==2.10',
         'Markdown==2.6.7',
         'PyYAML==3.11',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 from jinja2 import Environment, Markup
 
 from dmcontent.errors import ContentTemplateError, ContentNotFoundError
-from dmcontent.utils import TemplateField, get_option_value, try_load_manifest
+from dmcontent.utils import TemplateField, get_option_value, try_load_manifest, try_load_metadata, try_load_messages
 
 
 class TestTemplateField(object):
@@ -208,4 +208,88 @@ class TestTryLoadManifest:
                 TestTryLoadManifest.QUESTION_SET,
                 TestTryLoadManifest.MANIFEST,
                 TestTryLoadManifest.FRAMEWORK_DATA['slug']))
+        ]
+
+
+class TestTryLoadMetadata:
+    FRAMEWORK_DATA = {'slug': 'framework'}
+    METADATA = ['example']
+
+    def setup(self):
+        self.content_loader_mock = mock.Mock()
+        self.application_mock = mock.Mock()
+
+    def test_content_loader_asked_to_load_metadata(self):
+        try_load_metadata(self.content_loader_mock,
+                          self.application_mock,
+                          TestTryLoadMetadata.FRAMEWORK_DATA,
+                          TestTryLoadMetadata.METADATA
+                          )
+
+        assert self.content_loader_mock.load_metadata.call_args_list == [
+            mock.call(TestTryLoadMetadata.FRAMEWORK_DATA['slug'],
+                      TestTryLoadMetadata.METADATA)
+        ]
+        assert self.application_mock.logger.info.called is False
+
+    def test_info_log_generated_on_content_not_found(self):
+        self.content_loader_mock.load_metadata.side_effect = ContentNotFoundError()
+
+        try_load_metadata(self.content_loader_mock,
+                          self.application_mock,
+                          TestTryLoadMetadata.FRAMEWORK_DATA,
+                          TestTryLoadMetadata.METADATA
+                          )
+
+        assert self.content_loader_mock.load_metadata.call_args_list == [
+            mock.call(TestTryLoadMetadata.FRAMEWORK_DATA['slug'],
+                      TestTryLoadMetadata.METADATA)
+        ]
+
+        assert self.application_mock.logger.info.call_args_list == [
+            mock.call("Could not load '{}' metadata for {}".format(
+                TestTryLoadMetadata.METADATA,
+                TestTryLoadMetadata.FRAMEWORK_DATA['slug']))
+        ]
+
+
+class TestTryLoadMessages:
+    FRAMEWORK_DATA = {'slug': 'framework'}
+    MESSAGES = ['example']
+
+    def setup(self):
+        self.content_loader_mock = mock.Mock()
+        self.application_mock = mock.Mock()
+
+    def test_content_loader_asked_to_load_messages(self):
+        try_load_messages(self.content_loader_mock,
+                          self.application_mock,
+                          TestTryLoadMessages.FRAMEWORK_DATA,
+                          TestTryLoadMessages.MESSAGES
+                          )
+
+        assert self.content_loader_mock.load_messages.call_args_list == [
+            mock.call(TestTryLoadMessages.FRAMEWORK_DATA['slug'],
+                      TestTryLoadMessages.MESSAGES)
+        ]
+        assert self.application_mock.logger.info.called is False
+
+    def test_info_log_generated_on_content_not_found(self):
+        self.content_loader_mock.load_messages.side_effect = ContentNotFoundError()
+
+        try_load_messages(self.content_loader_mock,
+                          self.application_mock,
+                          TestTryLoadMessages.FRAMEWORK_DATA,
+                          TestTryLoadMessages.MESSAGES
+                          )
+
+        assert self.content_loader_mock.load_messages.call_args_list == [
+            mock.call(TestTryLoadMessages.FRAMEWORK_DATA['slug'],
+                      TestTryLoadMessages.MESSAGES)
+        ]
+
+        assert self.application_mock.logger.info.call_args_list == [
+            mock.call("Could not load '{}' messages for {}".format(
+                TestTryLoadMessages.MESSAGES,
+                TestTryLoadMessages.FRAMEWORK_DATA['slug']))
         ]


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/LjbF4cLc)

We have an existing util for handling exceptions when loading a
manifest. Versions of this for messages and metadata would also be
useful.

It'll help when loading content in `app.__init__.py` by saving having
conditionals for different framework versions.