### PR TITLE
Update requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info/
 *.pyc
 *.cache
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.egg-info/
 *.pyc
 *.cache
+.coverage
+.pytest_cache
 venv

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$V
 
 .PHONY: virtualenv
 virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
 
 .PHONY: requirements
 requirements: virtualenv requirements.txt

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '5.0.0'
+__version__ = '5.1.0'

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -25,7 +25,7 @@ class TemplateField(object):
 
     def make_template(self, field_value):
         env = DMSandboxedEnvironment(autoescape=True, undefined=StrictUndefined)
-        template = markdown(field_value, []) if self.markdown else field_value
+        template = markdown(field_value) if self.markdown else field_value
 
         return env.from_string(template)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ flake8-per-file-ignores==0.4.0
 mock==2.0.0
 pytest==3.2.3
 pytest-cov==2.5.1
-python-coveralls==2.5.0
+coveralls==1.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
-coverage==3.7.1
-flake8==3.5.0
-flake8-per-file-ignores==0.4.0
-mock==2.0.0
-pytest==3.2.3
-pytest-cov==2.5.1
-coveralls==1.5.0
+coverage
+coveralls
+flake8<4.0.0,>=3.5.0
+flake8-per-file-ignores
+mock
+pytest
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -e .
 # DON'T FORGET TO UPDATE setup.py !!
-git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.2.0#egg=digitalmarketplace-utils==44.2.0

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,12 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'Flask==1.0.2',
-        'Jinja2==2.10',
-        'Markdown==2.6.7',
-        'PyYAML==3.11',
-        'Werkzeug==0.14.1',
-        'inflection==0.3.1',
-        'digitalmarketplace-utils==44.0.1',
+        'Flask<1.1.0,>=1.0.2',
+        'Jinja2<2.11,>=2.10',
+        'Markdown<3.0.0,>=2.6.7',
+        'PyYAML<4.0,>=3.11',
+        'Werkzeug<0.15.0,>=0.14.1',
+        'inflection<1.0.0,>=0.3.1',
+        'digitalmarketplace-utils<45.0.0,>=44.0.1',
     ]
 )


### PR DESCRIPTION
This PR includes a bunch of house-cleaning stuff:

  - Use venv instead of virtualenv
  - Pin to version ranges instead of specific versions
  - Upgrade dmutils a few minor versions
  - Fix an annoying deprecation warning
  - Change our library for uploading to coveralls to one that is currently maintained

This contributes to closing https://trello.com/c/WoFsBnLE/