### PR TITLE
Support Python 3.6 only

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '5.1.2'
+__version__ = '5.1.3'

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setup(
         'Werkzeug<0.15.0,>=0.14.1',
         'inflection<1.0.0,>=0.3.1',
         'digitalmarketplace-utils<45.0.0,>=44.0.1',
-    ]
+    ],
+    python_requires="==3.6.*",
 )


### PR DESCRIPTION
Add python_requires specification to setup.py that explicitly declares which versions of Python this library supports/is tested on.

Part of https://trello.com/c/wWFsv1SU/230-be-clear-in-our-libraries-what-versions-of-python-we-support