### PR TITLE
Add a Python version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Digital Marketplace Content Loader
 ==================================
 
 [![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-content-loader/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-content-loader?branch=master)
+![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
 
 ## What's in here?

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '5.1.1'
+__version__ = '5.1.2'


### PR DESCRIPTION
Adds a nifty visual indicator of what versions of Python we support

Part of https://trello.com/c/wWFsv1SU/230-be-clear-in-our-libraries-what-versions-of-python-we-support