### PR TITLE
default.nix: ensure venv is created relative to default.nix, not cwd

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@ in (with args; {
 
     hardeningDisable = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "format" ];
 
-    VIRTUALENV_ROOT = "venv${pythonPackages.python.pythonVersion}";
+    VIRTUALENV_ROOT = (toString (./.)) + "/venv${pythonPackages.python.pythonVersion}";
     VIRTUAL_ENV_DISABLE_PROMPT = "1";
     SOURCE_DATE_EPOCH = "315532800";
 
@@ -37,7 +37,7 @@ in (with args; {
         ${pythonPackages.python}/bin/python -m venv $VIRTUALENV_ROOT
       fi
       source $VIRTUALENV_ROOT/bin/activate
-      make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
+      make -C ${toString (./.)} requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
     '';
   }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
 })

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ coveralls
 flake8<3.7.0,>=3.6.0
 flake8-per-file-ignores
 mock
-pytest
+pytest>=4.0.0
 pytest-cov


### PR DESCRIPTION
uninteresting to non-nixers