### PR TITLE
Update digitalmarketplace-utils

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '5.1.3'
+__version__ = '5.2.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -e .
 # DON'T FORGET TO UPDATE setup.py !!
-git+https://github.com/alphagov/digitalmarketplace-utils.git@44.2.0#egg=digitalmarketplace-utils==44.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@46.2.0#egg=digitalmarketplace-utils==46.2.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'PyYAML<4.0,>=3.11',
         'Werkzeug<0.15.0,>=0.14.1',
         'inflection<1.0.0,>=0.3.1',
-        'digitalmarketplace-utils<45.0.0,>=44.0.1',
+        'digitalmarketplace-utils<47.0.0,>=44.0.1',
     ],
     python_requires="==3.6.*",
 )


### PR DESCRIPTION
The current version of digitalmarketplace-content-loader will cause pip warnings due to requiring a version of dmutils<46.

This PR fixes those warnings by increasing the ceiling and bumping the version we test against.

There were no breaking changes that affected content-loader.