### PR TITLE
Bump -utils dependency

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '5.2.0'
+__version__ = '5.2.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -e .
 # DON'T FORGET TO UPDATE setup.py !!
-git+https://github.com/alphagov/digitalmarketplace-utils.git@46.2.0#egg=digitalmarketplace-utils==46.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,8 @@ setup(
         'Jinja2<2.11,>=2.10',
         'Markdown<3.0.0,>=2.6.7',
         'PyYAML<4.0,>=3.11',
-        'Werkzeug<0.15.0,>=0.14.1',
         'inflection<1.0.0,>=0.3.1',
-        'digitalmarketplace-utils<47.0.0,>=44.0.1',
+        'digitalmarketplace-utils<49.0.0,>=44.0.1',
     ],
     python_requires="==3.6.*",
 )


### PR DESCRIPTION
Also remove direct werkzeug dependency - we should be able to rely on flask including werkzeug and this library's use of it isn't tremendously version specific.

I've tested this version against both `44.0.1` and `48.2.0`.

Kept the upper limit of `-utils` versions, bumping it to `<49`, just so we get prompted to re-test it in the future.