### PR TITLE
TemplateField: make this deepcopy-able

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Records breaking changes from major version bumps
 
+## 6.0.0
+
+`utils.TemplateField`'s `template` attribute is no longer a real jinja `Template`, and now only has a single method,
+`render([context])`. On the plus side, `ContentLoader` trees should be deepcopy-able.
+
 ## 5.0.0
 
 PR [#59](https://github.com/alphagov/digitalmarketplace-content-loader/pull/59)

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '5.2.1'
+__version__ = '6.0.0'

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -9,6 +9,11 @@ from dmcontent.errors import ContentNotFoundError
 from .errors import ContentTemplateError
 
 
+# jinja's environments are threadsafe (unless you explicitly mutate them during operation, which is not recommended),
+# so it should be safe to keep this as a shared global
+template_environment = DMSandboxedEnvironment(autoescape=True, undefined=StrictUndefined)
+
+
 class TemplateField(object):
     def __init__(self, field_value, markdown=None):
         self.source = field_value
@@ -24,10 +29,9 @@ class TemplateField(object):
             raise ContentTemplateError(e.message)
 
     def make_template(self, field_value):
-        env = DMSandboxedEnvironment(autoescape=True, undefined=StrictUndefined)
         template = markdown(field_value) if self.markdown else field_value
 
-        return env.from_string(template)
+        return template_environment.from_string(template)
 
     def render(self, context=None):
         try:


### PR DESCRIPTION
https://trello.com/c/RW2tzjbM

Being able to deepcopy a full `ContentLoader` tree gives us a fast way of generating independent `ContentLoaders` for each local context. This approach cheats slightly my transforming the way we hold a reference to a jinja `Template` to be immutable, and therefore not actually _requiring_ a copy. This also means we can _share_ the jinja `Templates` associated with `TemplateField`s, which seem to be the most memory hungry and construction-time hungry parts of a `ContentLoader` tree.

I'm probably being a bit over-cautious in making this a major version bump. I don't think anything touches the internal `template` attribute of a `TemplateField`.