### PR TITLE
Upgrade PyYAML to 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Records breaking changes from major version bumps
 
 ## 7.0.0
 
-PR [TBC]()
+PR [#71](https://github.com/alphagov/digitalmarketplace-content-loader/pull/71)
 
 Removal of support for `python3.3` and lower.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Records breaking changes from major version bumps
 
+## 7.0.0
+
+PR [TBC]()
+
+Removal of support for `python3.3` and lower.
+
+Upgrade `PyYAML` from 3.11 to 5.1.2 (see [Changelog](https://github.com/yaml/pyyaml/blob/master/CHANGES)). 
+
 ## 6.0.0
 
 `utils.TemplateField`'s `template` attribute is no longer a real jinja `Template`, and now only has a single method,

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '6.0.0'
+__version__ = '7.0.0'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'Flask<1.1.0,>=1.0.2',
         'Jinja2<2.11,>=2.10',
         'Markdown<3.0.0,>=2.6.7',
-        'PyYAML<4.0,>=3.11',
+        'PyYAML<6.0,>=5.1.2',
         'inflection<1.0.0,>=0.3.1',
         'digitalmarketplace-utils<49.0.0,>=44.0.1',
     ],


### PR DESCRIPTION
https://trello.com/c/51brdJKx/1201-upgrade-pyyaml-to-5x

I've been cautious and made this a major bump, in case anyone was thinking of using this with an older version of Python.

We are careful to use `yaml.safeload()` instead of the vulnerable `yaml.load()`, but this version of PyYAML deprecates the latter completely so it's no longer even an option 😸  