### PR TITLE
Remove upper restriction on Python versions

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.1.0'
+__version__ = '7.1.1'

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         'inflection<1.0.0,>=0.3.1',
         'digitalmarketplace-utils>=44.0.1',
     ],
-    python_requires="==3.6.*",
+    python_requires="~=3.6",
 )


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

The ~= syntax denotes we don't fully support higher versions yet:

https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

See equivalent PRs for utils, API client and test utils:
https://github.com/alphagov/digitalmarketplace-utils/pull/544
https://github.com/alphagov/digitalmarketplace-apiclient/pull/225
https://github.com/alphagov/digitalmarketplace-test-utils/pull/25