### PR TITLE
utils: transplant count_unanswered_questions from supplier frontend

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.1.1'
+__version__ = '7.2.0'


### PR DESCRIPTION
We need to use this in the admin frontend for https://trello.com/c/g5P0RxQn and it makes more sense to have this in the content loader than `-utils`. I did look at making it a nice useful method of `ContentManifest` but it would be weird having a method that only works for a certain subset of `ContentManifest`s and you'd only find out if it worked once it dug into the questions it contained... meh.