### PR TITLE
performance improvements, largely through addition of "inplace_allowed" options

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.2.0'
+__version__ = '7.3.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -416,7 +416,7 @@ class ContentSection(object):
             question.inject_brief_questions_into_boolean_list_question(brief)
 
     def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> Optional["ContentSection"]:
-        section = self.copy()
+        section = self if inplace_allowed else self.copy()
         section._context = context
 
         filtered_questions = list(filter(None, [
@@ -424,10 +424,10 @@ class ContentSection(object):
             for question in self.questions
         ]))
 
+        section.questions = filtered_questions
+
         if not filtered_questions:
             return None
-
-        section.questions = filtered_questions
 
         return section
 

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -6,6 +6,8 @@ import re
 import os
 import copy
 
+from typing import Optional
+
 from collections import defaultdict, OrderedDict
 from functools import partial
 from werkzeug.datastructures import ImmutableMultiDict
@@ -101,14 +103,14 @@ class ContentManifest(object):
     def get_next_edit_questions_section_id(self, section_id=None):
         return self.get_next_section_id(section_id, only_edit_questions=True)
 
-    def filter(self, context, dynamic=True):
+    def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> "ContentManifest":
         """Return a new :class:`ContentManifest` filtered by service data
 
         Only includes the questions that should be shown for the provided
         service data. This is calculated by resolving the dependencies
         described by the `depends` section."""
         sections = filter(None, [
-            section.filter(context, dynamic)
+            section.filter(context, dynamic=dynamic, inplace_allowed=inplace_allowed)
             for section in self.sections
         ])
 
@@ -413,12 +415,12 @@ class ContentSection(object):
         for question in self.questions:
             question.inject_brief_questions_into_boolean_list_question(brief)
 
-    def filter(self, context, dynamic=True):
+    def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> Optional["ContentSection"]:
         section = self.copy()
         section._context = context
 
         filtered_questions = list(filter(None, [
-            question.filter(context, dynamic)
+            question.filter(context, dynamic=dynamic, inplace_allowed=inplace_allowed)
             for question in self.questions
         ]))
 

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -32,6 +32,9 @@ class ContentManifest(object):
     """
     def __init__(self, sections):
         self.sections = [ContentSection.create(section) for section in sections]
+        self._assign_question_numbers()
+
+    def _assign_question_numbers(self):
         question_index = 0
         for section in self.sections:
             for question in section.questions:
@@ -109,12 +112,17 @@ class ContentManifest(object):
         Only includes the questions that should be shown for the provided
         service data. This is calculated by resolving the dependencies
         described by the `depends` section."""
-        sections = filter(None, [
+        new_sections = filter(None, [
             section.filter(context, dynamic=dynamic, inplace_allowed=inplace_allowed)
             for section in self.sections
         ])
 
-        return ContentManifest(sections)
+        if inplace_allowed:
+            self.sections[:] = new_sections
+            self._assign_question_numbers()
+            return self
+        else:
+            return ContentManifest(new_sections)
 
     def get_question(self, field_name):
         for section in self.sections:

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -56,9 +56,13 @@ class ContentManifest(object):
         summary tables.
 
         """
-        return ContentManifest(
-            [section.summary(service_data, inplace_allowed=inplace_allowed) for section in self.sections]
-        )
+        new_sections = [section.summary(service_data, inplace_allowed=inplace_allowed) for section in self.sections]
+        if inplace_allowed:
+            self.sections[:] = new_sections
+            self._assign_question_numbers()
+            return self
+        else:
+            return ContentManifest(new_sections)
 
     def get_section(self, section_id):
         """Return a section by ID"""

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -41,7 +41,7 @@ class ContentManifest(object):
     def __iter__(self):
         return self.sections.__iter__()
 
-    def summary(self, service_data):
+    def summary(self, service_data, inplace_allowed: bool = False) -> "ContentManifest":
         """Create a manifest instance for service summary display
 
         Return a new :class:`ContentManifest` instance with all
@@ -54,7 +54,7 @@ class ContentManifest(object):
 
         """
         return ContentManifest(
-            [section.summary(service_data) for section in self.sections]
+            [section.summary(service_data, inplace_allowed=inplace_allowed) for section in self.sections]
         )
 
     def get_section(self, section_id):
@@ -190,9 +190,11 @@ class ContentSection(object):
                for key, value in object.__getattribute__(self, '__dict__').items()
                if key not in ['id']})
 
-    def summary(self, service_data):
+    def summary(self, service_data, inplace_allowed: bool = False) -> "ContentManifest":
         summary_section = self.copy()
-        summary_section.questions = [question.summary(service_data) for question in summary_section.questions]
+        summary_section.questions = [
+            question.summary(service_data, inplace_allowed=inplace_allowed) for question in summary_section.questions
+        ]
 
         return summary_section
 

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -191,7 +191,7 @@ class ContentSection(object):
                if key not in ['id']})
 
     def summary(self, service_data, inplace_allowed: bool = False) -> "ContentManifest":
-        summary_section = self.copy()
+        summary_section = self if inplace_allowed else self.copy()
         summary_section.questions = [
             question.summary(service_data, inplace_allowed=inplace_allowed) for question in summary_section.questions
         ]

--- a/dmcontent/messages.py
+++ b/dmcontent/messages.py
@@ -7,7 +7,7 @@ class ContentMessage(object):
         self._context = _context
 
     def filter(self, context, inplace_allowed: bool = False) -> "ContentMessage":
-        message = ContentMessage(self._data)
+        message = self if inplace_allowed else ContentMessage(self._data)
         message._context = context
 
         return message

--- a/dmcontent/messages.py
+++ b/dmcontent/messages.py
@@ -6,7 +6,7 @@ class ContentMessage(object):
         self._data = data.copy()
         self._context = _context
 
-    def filter(self, context):
+    def filter(self, context, inplace_allowed: bool = False) -> "ContentMessage":
         message = ContentMessage(self._data)
         message._context = context
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -191,16 +191,13 @@ class Question(object):
         return [self.id] if type in [self.type, None] else []
 
     def get(self, key, default=None):
-        try:
-            return getattr(self, key)
-        except AttributeError:
-            return default
+        return getattr(self, key, default)
 
     def __getattr__(self, key):
-        try:
-            field = self._data[key]
-        except KeyError:
+        if key not in self._data:
             raise AttributeError(key)
+
+        field = self._data[key]
 
         if isinstance(field, TemplateField):
             return field.render(self._context)

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -28,7 +28,7 @@ class Question(object):
         if not self._should_be_shown(context):
             return None
 
-        question = ContentQuestion(self._data, number=self.number)
+        question = self if inplace_allowed else ContentQuestion(self._data, number=self.number)
         question._context = context
 
         return question

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -185,7 +185,7 @@ class Question(object):
             self.boolean_list_questions = brief.get(self.id, [])
 
     def has_assurance(self):
-        return True if self.get('assuranceApproach') else False
+        return bool(self.get('assuranceApproach'))
 
     def get_question_ids(self, type=None):
         return [self.id] if type in [self.type, None] else []

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -668,7 +668,7 @@ class QuestionSummary(Question):
 
     @property
     def is_empty(self):
-        return self.value in ['', [], None]
+        return self.value in ('', [], None,)
 
     @property
     def value(self):
@@ -742,30 +742,43 @@ class MultiquestionSummary(QuestionSummary, Multiquestion):
 
     @property
     def answer_required(self):
-        """Checks all sub-questions and returns true if any questions which are required, still require answers.
-        Appropriately checks/ignores followup questions based on current answers."""
+        """
+            Checks all sub-questions and returns true if any questions which are required, still require answers.
+            Appropriately checks/ignores followup questions based on current answers.
+
+            NOTE this is a "hot path" so be careful making changes to it.
+        """
         if self.get('optional'):
             return False
 
         lookup_question_by_id = {q.id: q for q in self.questions}
-        followup_questions = set()
+        ignorable_ids = set()
 
-        for question in [q for q in self.questions if q.get('followup', {})]:
-            if question.id not in followup_questions and question.answer_required:
-                return True
+        # note iteration order is important here: followups coming "before" their referring question will cause trouble
+        for question in self.questions:
+            if not question.get('followup'):
+                continue
 
-            followup_questions.add(question.id)
+            if question.id not in ignorable_ids:
+                if question.answer_required:
+                    return True
+                else:
+                    # ignorable because it's not `.answer_required`
+                    ignorable_ids.add(question.id)
 
-            answers_provided = question.value if isinstance(question.value, list) else [question.value]
+            question_value = question.value
+            answers_provided_set = frozenset(question_value if isinstance(question_value, list) else (question_value,))
 
             for followup_id, answers_triggering_followup in question.get('followup', {}).items():
-                followup_questions.add(followup_id)
-
-                if set(answers_provided) & set(answers_triggering_followup) and \
+                if answers_provided_set.intersection(answers_triggering_followup) and \
                         lookup_question_by_id[followup_id].answer_required:
                     return True
 
-        return any(q.answer_required for q in self.questions if q.id not in followup_questions)
+                # ignorable because it's listed as a followup to a question that hasn't been triggered or is not
+                # `.answer_required`
+                ignorable_ids.add(followup_id)
+
+        return any(q.answer_required for q in self.questions if q.id not in ignorable_ids)
 
 
 class DynamicListSummary(MultiquestionSummary, DynamicList):

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -2,6 +2,8 @@ from collections import OrderedDict, defaultdict
 from datetime import datetime
 import re
 
+from typing import Optional
+
 from dmutils.formats import DATE_FORMAT, DISPLAY_DATE_FORMAT
 
 from .converters import convert_to_boolean, convert_to_number
@@ -22,7 +24,7 @@ class Question(object):
     def summary(self, service_data):
         return QuestionSummary(self, service_data)
 
-    def filter(self, context, dynamic=True):
+    def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> Optional["Question"]:
         if not self._should_be_shown(context):
             return None
 
@@ -243,13 +245,13 @@ class Multiquestion(Question):
     def summary(self, service_data):
         return MultiquestionSummary(self, service_data)
 
-    def filter(self, context, dynamic=True):
-        multi_question = super(Multiquestion, self).filter(context, dynamic)
+    def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> Optional["Question"]:
+        multi_question = super(Multiquestion, self).filter(context, dynamic=dynamic, inplace_allowed=inplace_allowed)
         if not multi_question:
             return None
 
         multi_question.questions = list(filter(None, [
-            question.filter(context, dynamic)
+            question.filter(context, dynamic, inplace_allowed=inplace_allowed)
             for question in multi_question.questions
         ]))
 
@@ -301,11 +303,15 @@ class DynamicList(Multiquestion):
         super(DynamicList, self).__init__(data, *args, **kwargs)
         self.type = 'multiquestion'  # same UI components as Multiquestion
 
-    def filter(self, context, dynamic=True):
+    def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> Optional["Question"]:
         if not dynamic:
-            return super(DynamicList, self).filter(context, dynamic)
+            return super(DynamicList, self).filter(context, dynamic=dynamic, inplace_allowed=inplace_allowed)
 
-        dynamic_list = super(Multiquestion, self).filter(context, dynamic)
+        dynamic_list = super(Multiquestion, self).filter(
+            context,
+            dynamic=dynamic,
+            inplace_allowed=inplace_allowed,
+        )
         if not dynamic_list:
             return None
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -21,7 +21,7 @@ class Question(object):
         self._data = data.copy()
         self._context = _context
 
-    def summary(self, service_data):
+    def summary(self, service_data, inplace_allowed: bool = False) -> "QuestionSummary":
         return QuestionSummary(self, service_data)
 
     def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> Optional["Question"]:
@@ -242,7 +242,7 @@ class Multiquestion(Question):
             for question in data['questions']
         ]
 
-    def summary(self, service_data):
+    def summary(self, service_data, inplace_allowed: bool = False) -> "MultiquestionSummary":
         return MultiquestionSummary(self, service_data)
 
     def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> Optional["Question"]:
@@ -452,7 +452,7 @@ class DynamicList(Multiquestion):
     def form_fields(self):
         return [self.id]
 
-    def summary(self, service_data):
+    def summary(self, service_data, inplace_allowed: bool = False) -> "DynamicListSummary":
         return DynamicListSummary(self, service_data)
 
     def _make_dynamic_question(self, question, item, index):
@@ -476,7 +476,7 @@ class Pricing(Question):
         # True if we are restricting to an integer or a 2dp value (representing pounds and optionally pence)
         self.decimal_place_restriction = data.get('decimal_place_restriction', False)
 
-    def summary(self, service_data):
+    def summary(self, service_data, inplace_allowed: bool = False) -> "PricingSummary":
         return PricingSummary(self, service_data)
 
     def get_question(self, field_name):
@@ -532,7 +532,7 @@ class List(Question):
 
         return {self.id: value or None}
 
-    def summary(self, service_data):
+    def summary(self, service_data, inplace_allowed: bool = False) -> "ListSummary":
         return ListSummary(self, service_data)
 
 
@@ -556,7 +556,7 @@ class Hierarchy(List):
 
         return {self.id: sorted(values) or None}
 
-    def summary(self, service_data):
+    def summary(self, service_data, inplace_allowed: bool = False) -> "HierarchySummary":
         return HierarchySummary(self, service_data)
 
     def get_missing_values(self, selected_values_set):
@@ -587,7 +587,7 @@ class Date(Question):
 
     FIELDS = ('year', 'month', 'day')
 
-    def summary(self, service_data):
+    def summary(self, service_data, inplace_allowed: bool = False) -> "DateSummary":
         return DateSummary(self, service_data)
 
     @staticmethod

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -114,7 +114,8 @@ class TestContentManifest(object):
 
         assert [s.id for s in content] == [1, 2, 3]
 
-    def test_a_question_with_a_dependency(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_a_question_with_a_dependency(self, filter_inplace_allowed):
         content = ContentManifest([{
             "slug": "first_section",
             "name": "First section",
@@ -126,11 +127,12 @@ class TestContentManifest(object):
                     "being": ["SCS"]
                 }]
             }]
-        }]).filter({"lot": "SCS"})
+        }]).filter({"lot": "SCS"}, inplace_allowed=filter_inplace_allowed)
 
         assert len(content.sections) == 1
 
-    def test_missing_depends_key_filter(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_missing_depends_key_filter(self, filter_inplace_allowed):
         content = ContentManifest([{
             "slug": "first_section",
             "name": "First section",
@@ -142,11 +144,12 @@ class TestContentManifest(object):
                     "being": ["SCS"]
                 }]
             }]
-        }]).filter({})
+        }]).filter({}, inplace_allowed=filter_inplace_allowed)
 
         assert len(content.sections) == 0
 
-    def test_question_without_dependencies(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_question_without_dependencies(self, filter_inplace_allowed):
         content = ContentManifest([{
             "slug": "first_section",
             "name": "First section",
@@ -154,11 +157,12 @@ class TestContentManifest(object):
                 "id": "q1",
                 "question": 'First question',
             }]
-        }]).filter({'lot': 'SaaS'})
+        }]).filter({'lot': 'SaaS'}, inplace_allowed=filter_inplace_allowed)
 
         assert len(content.sections) == 1
 
-    def test_a_question_with_a_dependency_that_doesnt_match(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_a_question_with_a_dependency_that_doesnt_match(self, filter_inplace_allowed):
         content = ContentManifest([{
             "slug": "first_section",
             "name": "First section",
@@ -170,11 +174,12 @@ class TestContentManifest(object):
                     "being": ["SCS"]
                 }]
             }]
-        }]).filter({"lot": "SaaS"})
+        }]).filter({"lot": "SaaS"}, inplace_allowed=filter_inplace_allowed)
 
         assert len(content.sections) == 0
 
-    def test_a_question_which_depends_on_one_of_several_answers(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_a_question_which_depends_on_one_of_several_answers(self, filter_inplace_allowed):
         content = ContentManifest([{
             "slug": "first_section",
             "name": "First section",
@@ -188,11 +193,12 @@ class TestContentManifest(object):
             }]
         }])
 
-        assert len(content.filter({"lot": "SaaS"}).sections) == 1
-        assert len(content.filter({"lot": "PaaS"}).sections) == 1
-        assert len(content.filter({"lot": "SCS"}).sections) == 1
+        assert len(content.filter({"lot": "SaaS"}, inplace_allowed=filter_inplace_allowed).sections) == 1
+        assert len(content.filter({"lot": "PaaS"}, inplace_allowed=filter_inplace_allowed).sections) == 1
+        assert len(content.filter({"lot": "SCS"}, inplace_allowed=filter_inplace_allowed).sections) == 1
 
-    def test_a_question_which_shouldnt_be_shown(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_a_question_which_shouldnt_be_shown(self, filter_inplace_allowed):
         content = ContentManifest([{
             "slug": "first_section",
             "name": "First section",
@@ -206,9 +212,10 @@ class TestContentManifest(object):
             }]
         }])
 
-        assert len(content.filter({"lot": "IaaS"}).sections) == 0
+        assert len(content.filter({"lot": "IaaS"}, inplace_allowed=filter_inplace_allowed).sections) == 0
 
-    def test_a_section_which_has_a_mixture_of_dependencies(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_a_section_which_has_a_mixture_of_dependencies(self, filter_inplace_allowed):
         content = ContentManifest([{
             "slug": "first_section",
             "name": "First section",
@@ -230,7 +237,7 @@ class TestContentManifest(object):
                     }]
                 },
             ]
-        }]).filter({"lot": "IaaS"})
+        }]).filter({"lot": "IaaS"}, inplace_allowed=filter_inplace_allowed)
 
         assert len(content.sections) == 1
 
@@ -263,7 +270,8 @@ class TestContentManifest(object):
         assert len(content.sections[0]["questions"]) == 2
         assert len(content2.sections[0]["questions"]) == 1
 
-    def test_that_filtering_is_cumulative(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_that_filtering_is_cumulative(self, filter_inplace_allowed):
         content = ContentManifest([{
             "slug": "first_section",
             "name": "First section",
@@ -295,16 +303,17 @@ class TestContentManifest(object):
             ]
         }])
 
-        content = content.filter({"lot": "SCS"})
+        content = content.filter({"lot": "SCS"}, inplace_allowed=filter_inplace_allowed)
         assert len(content.sections[0]["questions"]) == 2
 
-        content = content.filter({"lot": "IaaS"})
+        content = content.filter({"lot": "IaaS"}, inplace_allowed=filter_inplace_allowed)
         assert len(content.sections[0]["questions"]) == 1
 
-        content = content.filter({"lot": "PaaS"})
+        content = content.filter({"lot": "PaaS"}, inplace_allowed=filter_inplace_allowed)
         assert len(content.sections) == 0
 
-    def test_get_section(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_get_section(self, filter_inplace_allowed):
         content = ContentManifest([{
             "slug": "first_section",
             "name": "First section",
@@ -322,7 +331,7 @@ class TestContentManifest(object):
 
         assert content.get_section("first_section").id == "first_section"
 
-        content = content.filter({"lot": "IaaS"})
+        content = content.filter({"lot": "IaaS"}, inplace_allowed=filter_inplace_allowed)
         assert content.get_section("first_section") is None
 
     def test_summary(self):
@@ -419,7 +428,8 @@ class TestContentManifest(object):
         assert summary.get_question('q13').answer_required
         assert not summary.get_question('q14').answer_required
 
-    def test_get_question(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_get_question(self, filter_inplace_allowed):
         content = ContentManifest([
             {
                 "slug": "first_section",
@@ -462,7 +472,7 @@ class TestContentManifest(object):
 
         assert content.get_question('q1').get('id') == 'q1'
 
-        content = content.filter({'lot': 'IaaS'})
+        content = content.filter({'lot': 'IaaS'}, inplace_allowed=filter_inplace_allowed)
         assert content.get_question('q1') is None
 
     def test_get_question_by_slug(self):
@@ -605,7 +615,8 @@ class TestContentManifest(object):
         assert content.get_question("q2")['number'] == 2
         assert content.get_question("q3")['number'] == 3
 
-    def test_question_numbers_respect_filtering(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_question_numbers_respect_filtering(self, filter_inplace_allowed):
         content = ContentManifest([
             {
                 "slug": "first_section",
@@ -641,7 +652,7 @@ class TestContentManifest(object):
                     },
                 ]
             }
-        ]).filter({"lot": "SCS"})
+        ]).filter({"lot": "SCS"}, inplace_allowed=filter_inplace_allowed)
 
         assert content.sections[0].questions[0]['id'] == 'q2'
         assert content.get_question('q2')['number'] == 1
@@ -698,7 +709,8 @@ class TestContentSection(object):
         })
         assert section.has_summary_page is True
 
-    def test_has_no_summary_page_if_single_question_no_description(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_has_no_summary_page_if_single_question_no_description(self, filter_inplace_allowed):
         section = ContentSection.create({
             "slug": "first_section",
             "name": "First section",
@@ -707,10 +719,11 @@ class TestContentSection(object):
                 "question": "Boolean question",
                 "type": "boolean",
             }]
-        }).filter({})
+        }).filter({}, inplace_allowed=filter_inplace_allowed)
         assert section.has_summary_page is False
 
-    def test_has_summary_page_if_single_question_with_description(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_has_summary_page_if_single_question_with_description(self, filter_inplace_allowed):
         section = ContentSection.create({
             "slug": "first_section",
             "name": "First section",
@@ -720,7 +733,7 @@ class TestContentSection(object):
                 "question": "Boolean question",
                 "type": "boolean",
             }]
-        }).filter({})
+        }).filter({}, inplace_allowed=filter_inplace_allowed)
         assert section.has_summary_page is True
 
     def test_get_question_ids(self):
@@ -942,7 +955,8 @@ class TestContentSection(object):
         })
         assert section.get_previous_question_slug(None) is None
 
-    def test_get_multiquestion_as_section(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_get_multiquestion_as_section(self, filter_inplace_allowed):
         section = ContentSection.create({
             "slug": "first_section",
             "prefill": True,
@@ -966,7 +980,7 @@ class TestContentSection(object):
                     }
                 ]
             }]
-        }).filter({})
+        }).filter({}, inplace_allowed=filter_inplace_allowed)
 
         question_section = section.get_question_as_section('q0-slug')
         assert question_section.name == "Q0"
@@ -975,14 +989,15 @@ class TestContentSection(object):
         assert question_section.editable == section.edit_questions
         assert question_section.get_question_ids() == ['q2', 'q3']
 
-    def test_get_non_multiquestion_question_as_section(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_get_non_multiquestion_question_as_section(self, filter_inplace_allowed):
         section = ContentSection.create({
             "slug": "first_section",
             "edit_questions": True,
             "name": "First section",
             "questions": [{"id": "q1", "type": "text", "slug": "q1-slug", "question": "Q1", "hint": "Some description"},
                           {"id": "q2", "type": "text", "slug": "q2-slug", "question": "Q2", "hint": "Some description"}]
-        }).filter({})
+        }).filter({}, inplace_allowed=filter_inplace_allowed)
 
         question_section = section.get_question_as_section('q1-slug')
         assert question_section.slug == "q1-slug"
@@ -1612,14 +1627,15 @@ class TestContentSection(object):
         for error_key in ['q0', 'q0-0', 'q0-1', 'q0-2', 'q0-3']:
             assert error_key in error_messages
 
-    def test_section_description(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_section_description(self, filter_inplace_allowed):
         section = ContentSection.create({
             "slug": "first_section",
             "name": "First section",
             "questions": [{"id": "q1", "question": "Why?", "type": "text"}],
             "description": "This is the first section",
             "summary_page_description": "This is a summary of the first section"
-        }).filter({})
+        }).filter({}, inplace_allowed=filter_inplace_allowed)
         assert section.description == "This is the first section"
         assert section.summary_page_description == "This is a summary of the first section"
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -334,7 +334,8 @@ class TestContentManifest(object):
         content = content.filter({"lot": "IaaS"}, inplace_allowed=filter_inplace_allowed)
         assert content.get_section("first_section") is None
 
-    def test_summary(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_summary(self, summary_inplace_allowed):
         content = ContentManifest([{
             "slug": "first_section",
             "name": "First section",
@@ -403,7 +404,7 @@ class TestContentManifest(object):
             'q7.unit': 'day',
             'q10': {'value': True, 'assurance': 'Service provider assertion'},
             'q11': {'value': True}
-        })
+        }, inplace_allowed=summary_inplace_allowed)
 
         assert summary.get_question('q1').value == [
             summary.get_question('q2')
@@ -1524,7 +1525,8 @@ class TestContentSection(object):
         with pytest.raises(QuestionNotFoundError):
             section.get_error_messages(errors)
 
-    def test_get_error_messages_for_boolean_list_one_question_missing(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_get_error_messages_for_boolean_list_one_question_missing(self, summary_inplace_allowed):
 
         section, brief, form_data = self.setup_for_boolean_list_tests()
         form_data.pop('q0-3')
@@ -1533,7 +1535,7 @@ class TestContentSection(object):
         section = ContentSection.create(section)
         section.inject_brief_questions_into_boolean_list_question(brief['briefs'])
         response_data = section.get_data(form_data)
-        section_summary = section.summary(response_data)
+        section_summary = section.summary(response_data, inplace_allowed=summary_inplace_allowed)
         error_messages = section_summary.get_error_messages(errors)
 
         assert error_messages['q0'] is True
@@ -1542,7 +1544,8 @@ class TestContentSection(object):
             base_error_key, index = error_key.split('-')[0], int(error_key.split('-')[-1])
             assert brief['briefs'][base_error_key][index] == error_messages[error_key]['question']
 
-    def test_get_error_messages_for_boolean_list_all_questions_missing(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_get_error_messages_for_boolean_list_all_questions_missing(self, summary_inplace_allowed):
 
         section, brief, form_data = self.setup_for_boolean_list_tests()
         form_data.pop('q0-0')
@@ -1554,7 +1557,7 @@ class TestContentSection(object):
         section = ContentSection.create(section)
         section.inject_brief_questions_into_boolean_list_question(brief['briefs'])
         response_data = section.get_data(form_data)
-        section_summary = section.summary(response_data)
+        section_summary = section.summary(response_data, inplace_allowed=summary_inplace_allowed)
         error_messages = section_summary.get_error_messages(errors)
 
         assert error_messages['q0'] is True
@@ -1563,7 +1566,8 @@ class TestContentSection(object):
             base_error_key, index = error_key.split('-')[0], int(error_key.split('-')[-1])
             assert brief['briefs'][base_error_key][index] == error_messages[error_key]['question']
 
-    def test_get_error_messages_no_boolean_list_questions_missing(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_get_error_messages_no_boolean_list_questions_missing(self, summary_inplace_allowed):
 
         section, brief, form_data = self.setup_for_boolean_list_tests()
         section['questions'].append({
@@ -1576,7 +1580,7 @@ class TestContentSection(object):
         section = ContentSection.create(section)
         section.inject_brief_questions_into_boolean_list_question(brief['briefs'])
         response_data = section.get_data(form_data)
-        section_summary = section.summary(response_data)
+        section_summary = section.summary(response_data, inplace_allowed=summary_inplace_allowed)
         error_messages = section_summary.get_error_messages(errors)
 
         assert 'q1' in error_messages
@@ -1597,7 +1601,8 @@ class TestContentSection(object):
         assert 'q0-3' not in error_messages
         assert len(error_messages.keys()) == 1
 
-    def test_get_wrong_boolean_list_error_messages_without_brief_questions_injected(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_get_wrong_boolean_list_error_messages_without_brief_questions_injected(self, summary_inplace_allowed):
 
         section, brief, form_data = self.setup_for_boolean_list_tests()
         form_data.pop('q0-3')
@@ -1605,14 +1610,15 @@ class TestContentSection(object):
 
         section = ContentSection.create(section)
         response_data = section.get_data(form_data)
-        section_summary = section.summary(response_data)
+        section_summary = section.summary(response_data, inplace_allowed=summary_inplace_allowed)
         error_messages = section_summary.get_error_messages(errors)
 
         assert 'q0' in error_messages
         assert 'q0-3' not in error_messages
         assert len(error_messages.keys()) == 1
 
-    def test_get_wrong_boolean_list_error_messages_without_response_data(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_get_wrong_boolean_list_error_messages_without_response_data(self, summary_inplace_allowed):
 
         section, brief, form_data = self.setup_for_boolean_list_tests()
         form_data.pop('q0-3')
@@ -1620,7 +1626,7 @@ class TestContentSection(object):
 
         section = ContentSection.create(section)
         section.inject_brief_questions_into_boolean_list_question(brief['briefs'])
-        section_summary = section.summary({})
+        section_summary = section.summary({}, inplace_allowed=summary_inplace_allowed)
         error_messages = section_summary.get_error_messages(errors)
 
         # when an error key exists but no response data, all questions are assumed empty
@@ -1688,7 +1694,8 @@ class TestContentSection(object):
         with pytest.raises(ContentNotFoundError):
             section.inject_brief_questions_into_boolean_list_question(brief['briefs'])
 
-    def test_inject_messages_into_section_and_section_summary(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_inject_messages_into_section_and_section_summary(self, summary_inplace_allowed):
 
         section, brief, form_data = self.setup_for_boolean_list_tests()
         section['questions'].append({
@@ -1701,7 +1708,7 @@ class TestContentSection(object):
         section = ContentSection.create(section)
         section.inject_brief_questions_into_boolean_list_question(brief['briefs'])
         response_data = section.get_data(form_data)
-        section_summary = section.summary(response_data)
+        section_summary = section.summary(response_data, inplace_allowed=summary_inplace_allowed)
         assert section_summary.get_question('q0').value == [True, True, True, True]
         assert section_summary.get_question('q0').get('boolean_list_questions') == brief['briefs']['q0']
 

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -162,7 +162,14 @@ class TestFilterContentSection(object):
         assert copied_section.prefill is False
         assert copied_section.editable is False
 
-    def test_is_empty(self):
+    @pytest.mark.parametrize("summary_arg,expect_empty", (
+        ({'q1': 'a1', 'q2': 'a2'}, False,),
+        ({'q1': 'a1', 'q2': ''}, False,),
+        ({'q1': '', 'q2': ''}, True,),
+        ({}, True,),
+    ))
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_is_empty(self, summary_arg, expect_empty, summary_inplace_allowed):
         questions = [
             Question({'id': 'q1', 'name': 'q1', 'type': 'unknown'}),
             Question({'id': 'q2', 'name': 'q2', 'type': 'unknown'})
@@ -176,12 +183,7 @@ class TestFilterContentSection(object):
             edit_questions=False,
             questions=questions
         )
-        answered = section.summary({'q1': 'a1', 'q2': 'a2'})
-        assert not answered.is_empty
-        half_answered = section.summary({'q1': 'a1', 'q2': ''})
-        assert not half_answered.is_empty
-        not_answered = section.summary({'q1': '', 'q2': ''})
-        assert not_answered.is_empty
+        assert section.summary(summary_arg, inplace_allowed=summary_inplace_allowed).is_empty is expect_empty
 
     @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
     def test_getting_a_multiquestion_as_a_section_preserves_value_of_context_attribute(self, filter_inplace_allowed):

--- a/tests/test_content_section.py
+++ b/tests/test_content_section.py
@@ -9,7 +9,8 @@ from dmcontent import ContentTemplateError
 
 
 class TestFilterContentSection(object):
-    def test_fields_without_template_tags_are_unchanged(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_fields_without_template_tags_are_unchanged(self, filter_inplace_allowed):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section'),
@@ -20,11 +21,14 @@ class TestFilterContentSection(object):
             questions=[Question({})]
         )
 
-        assert section.filter({}).name == 'Section'
-        assert section.filter({}).description == 'just a string'
-        assert section.filter({}).prefill is True
+        sf = section.filter({}, inplace_allowed=filter_inplace_allowed)
 
-    def test_question_fields_without_template_tags_are_unchanged(self):
+        assert sf.name == 'Section'
+        assert sf.description == 'just a string'
+        assert sf.prefill is True
+
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_question_fields_without_template_tags_are_unchanged(self, filter_inplace_allowed):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section'),
@@ -34,9 +38,10 @@ class TestFilterContentSection(object):
             questions=[Question({'name': 'Question'})]
         )
 
-        assert section.filter({}).questions[0].name == 'Question'
+        assert section.filter({}, inplace_allowed=filter_inplace_allowed).questions[0].name == 'Question'
 
-    def test_not_all_fields_are_templated(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_not_all_fields_are_templated(self, filter_inplace_allowed):
         section = ContentSection(
             slug='# {{ section }}',
             name=TemplateField('Section'),
@@ -46,9 +51,10 @@ class TestFilterContentSection(object):
             questions=[Question({})]
         )
 
-        assert section.filter({}).slug == '# {{ section }}'
+        assert section.filter({}, inplace_allowed=filter_inplace_allowed).slug == '# {{ section }}'
 
-    def test_missing_context_variable_raises_an_error(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_missing_context_variable_raises_an_error(self, filter_inplace_allowed):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section {{ name }}'),
@@ -59,9 +65,10 @@ class TestFilterContentSection(object):
         )
 
         with pytest.raises(ContentTemplateError):
-            section.filter({}).name
+            section.filter({}, inplace_allowed=filter_inplace_allowed).name
 
-    def test_section_name_is_templated(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_section_name_is_templated(self, filter_inplace_allowed):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section {{ name }}'),
@@ -71,9 +78,10 @@ class TestFilterContentSection(object):
             questions=[Question({})]
         )
 
-        assert section.filter({'name': 'one'}).name == 'Section one'
+        assert section.filter({'name': 'one'}, inplace_allowed=filter_inplace_allowed).name == 'Section one'
 
-    def test_unused_context_variables_are_ignored(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_unused_context_variables_are_ignored(self, filter_inplace_allowed):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section {{ name }}'),
@@ -83,9 +91,13 @@ class TestFilterContentSection(object):
             questions=[Question({})]
         )
 
-        assert section.filter({'name': 'one', 'name2': 'ignored'}).name == 'Section one'
+        assert section.filter(
+            {'name': 'one', 'name2': 'ignored'},
+            inplace_allowed=filter_inplace_allowed,
+        ).name == 'Section one'
 
-    def test_section_description_is_templated(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_section_description_is_templated(self, filter_inplace_allowed):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section one'),
@@ -96,9 +108,13 @@ class TestFilterContentSection(object):
             description=TemplateField("This is the {{ name }} section")
         )
 
-        assert section.filter({'name': 'first'}).description == 'This is the first section'
+        assert section.filter(
+            {'name': 'first'},
+            inplace_allowed=filter_inplace_allowed,
+        ).description == 'This is the first section'
 
-    def test_section_description_is_not_set(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_section_description_is_not_set(self, filter_inplace_allowed):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section one'),
@@ -108,7 +124,7 @@ class TestFilterContentSection(object):
             questions=[Question({})]
         )
 
-        assert section.filter({}).description is None
+        assert section.filter({}, inplace_allowed=filter_inplace_allowed).description is None
 
     def test_get_templatable_section_attributes_calls_render(self):
         section = ContentSection(
@@ -129,7 +145,8 @@ class TestFilterContentSection(object):
 
         assert section.slug == 'section'
 
-    def test_copying_section_preserves_value_of_context_attribute(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_copying_section_preserves_value_of_context_attribute(self, filter_inplace_allowed):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section'),
@@ -137,7 +154,7 @@ class TestFilterContentSection(object):
             editable=False,
             edit_questions=False,
             questions=[Question({'name': 'Question'})]
-        ).filter({'context': 'context1'})
+        ).filter({'context': 'context1'}, inplace_allowed=filter_inplace_allowed)
         assert section._context == {'context': 'context1'}
 
         copied_section = section.copy()
@@ -166,7 +183,8 @@ class TestFilterContentSection(object):
         not_answered = section.summary({'q1': '', 'q2': ''})
         assert not_answered.is_empty
 
-    def test_getting_a_multiquestion_as_a_section_preserves_value_of_context_attribute(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    def test_getting_a_multiquestion_as_a_section_preserves_value_of_context_attribute(self, filter_inplace_allowed):
         multiquestion_data = {
             "id": "example",
             "slug": "example",
@@ -195,10 +213,16 @@ class TestFilterContentSection(object):
 
         assert section.get_question_as_section('example')._context is None
         assert section.filter(
-            {'context': 'context1'}
+            {'context': 'context1'},
+            inplace_allowed=filter_inplace_allowed,
         ).get_question_as_section('example')._context == {'context': 'context1'}
 
-    def test_filtering_a_section_with_a_description_template(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    @pytest.mark.parametrize("lot,expected_description", (
+        ("digital-specialists", "description for specialists",),
+        ("digital-outcomes", "description for outcomes",),
+    ))
+    def test_filtering_a_section_with_a_description_template(self, filter_inplace_allowed, lot, expected_description):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section one'),
@@ -211,10 +235,19 @@ class TestFilterContentSection(object):
             )
         )
 
-        assert section.filter({"lot": "digital-specialists"}).description == "description for specialists"
-        assert section.filter({"lot": "digital-outcomes"}).description == "description for outcomes"
+        assert section.filter(
+            {"lot": lot},
+            inplace_allowed=filter_inplace_allowed,
+        ).description == expected_description
 
-    def test_question_followup_get_data(self):
+    @pytest.mark.parametrize("filter_inplace_allowed", (False, True,))
+    @pytest.mark.parametrize("get_data_arg,expected_retval", (
+        (MultiDict([('q1', 'false')]), {'q1': False},),
+        (MultiDict([('q1', 'true')]), {'q1': True, 'q2': None},),
+        (MultiDict([('q1', 'false'), ('q2', 'true')]), {'q1': False, 'q2': True},),
+        (MultiDict([('q1', 'true'), ('q2', 'true')]), {'q1': True, 'q2': None},),
+    ))
+    def test_question_followup_get_data(self, filter_inplace_allowed, get_data_arg, expected_retval):
         section = ContentSection(
             slug='section',
             name=TemplateField('Section one'),
@@ -223,13 +256,6 @@ class TestFilterContentSection(object):
             edit_questions=False,
             questions=[Question({'id': 'q1', 'followup': {'q2': [False]}, 'type': 'boolean'}),
                        Question({'id': 'q2', 'type': 'boolean'})]
-        ).filter({})
+        ).filter({}, inplace_allowed=filter_inplace_allowed)
 
-        assert section.get_data(MultiDict([('q1', 'false')])) == {'q1': False}
-        assert section.get_data(MultiDict([('q1', 'true')])) == {'q1': True, 'q2': None}
-        assert section.get_data(
-            MultiDict([('q1', 'false'), ('q2', 'true')])
-        ) == {'q1': False, 'q2': True}
-        assert section.get_data(
-            MultiDict([('q1', 'true'), ('q2', 'true')])
-        ) == {'q1': True, 'q2': None}
+        assert section.get_data(get_data_arg) == expected_retval

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -829,24 +829,29 @@ class TestCheckboxTree(QuestionTest):
 
 
 class QuestionSummaryTest(object):
-    def test_value_missing(self):
-        question = self.question().summary({})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_missing(self, summary_inplace_allowed):
+        question = self.question().summary({}, inplace_allowed=summary_inplace_allowed)
         assert question.value == ''
 
-    def test_answer_required_value_missing(self):
-        question = self.question().summary({})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_required_value_missing(self, summary_inplace_allowed):
+        question = self.question().summary({}, inplace_allowed=summary_inplace_allowed)
         assert question.answer_required
 
-    def test_answer_required_optional_question(self):
-        question = self.question(optional=True).summary({})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_required_optional_question(self, summary_inplace_allowed):
+        question = self.question(optional=True).summary({}, inplace_allowed=summary_inplace_allowed)
         assert not question.answer_required
 
-    def test_is_empty_value_missing(self):
-        question = self.question().summary({})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_is_empty_value_missing(self, summary_inplace_allowed):
+        question = self.question().summary({}, inplace_allowed=summary_inplace_allowed)
         assert question.is_empty
 
-    def test_is_empty_optional_question(self):
-        question = self.question(optional=True).summary({})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_is_empty_optional_question(self, summary_inplace_allowed):
+        question = self.question(optional=True).summary({}, inplace_allowed=summary_inplace_allowed)
         assert question.is_empty
 
 
@@ -861,17 +866,20 @@ class TestDateSummary(QuestionSummaryTest):
 
         return ContentQuestion(data)
 
-    def test_date_is_formatted_into_user_friendly_format(self):
-        question = self.question().summary({'example': '2016-02-18'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_date_is_formatted_into_user_friendly_format(self, summary_inplace_allowed):
+        question = self.question().summary({'example': '2016-02-18'}, inplace_allowed=summary_inplace_allowed)
         assert question.value == 'Thursday 18 February 2016'
 
-    def test_unpadded_date_is_formatted_into_user_friendly_format(self):
-        question = self.question().summary({'example': '2003-2-1'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_unpadded_date_is_formatted_into_user_friendly_format(self, summary_inplace_allowed):
+        question = self.question().summary({'example': '2003-2-1'}, inplace_allowed=summary_inplace_allowed)
         assert question.value == 'Saturday 1 February 2003'
 
-    def test_not_a_date_format_falls_back_to_raw_string(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_not_a_date_format_falls_back_to_raw_string(self, summary_inplace_allowed):
         non_date_string = 'not-a-date-formatted-string'
-        question = self.question().summary({'example': non_date_string})
+        question = self.question().summary({'example': non_date_string}, inplace_allowed=summary_inplace_allowed)
 
         assert question.value == non_date_string
 
@@ -889,10 +897,10 @@ class TestDateSummary(QuestionSummaryTest):
         question = self.question().summary({'example': '2016-02-18'})
         assert not question.is_empty
 
-    def test_date_before_1900(self):
-
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_date_before_1900(self, summary_inplace_allowed):
         old_date_string = '1899-01-01' if six.PY2 else 'Sunday 1 January 1899'
-        question = self.question().summary({'example': old_date_string})
+        question = self.question().summary({'example': old_date_string}, inplace_allowed=summary_inplace_allowed)
 
         assert question.value == old_date_string
 
@@ -907,20 +915,24 @@ class TestTextSummary(QuestionSummaryTest):
 
         return ContentQuestion(data)
 
-    def test_value(self):
-        question = self.question().summary({'example': 'textvalue'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value(self, summary_inplace_allowed):
+        question = self.question().summary({'example': 'textvalue'}, inplace_allowed=summary_inplace_allowed)
         assert question.value == 'textvalue'
 
-    def test_value_empty(self):
-        question = self.question().summary({'example': ''})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_empty(self, summary_inplace_allowed):
+        question = self.question().summary({'example': ''}, inplace_allowed=summary_inplace_allowed)
         assert question.value == ''
 
-    def test_answer_required(self):
-        question = self.question().summary({'example': 'value1'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_required(self, summary_inplace_allowed):
+        question = self.question().summary({'example': 'value1'}, inplace_allowed=summary_inplace_allowed)
         assert not question.answer_required
 
-    def test_is_empty(self):
-        question = self.question().summary({'example': 'value1'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_is_empty(self, summary_inplace_allowed):
+        question = self.question().summary({'example': 'value1'}, inplace_allowed=summary_inplace_allowed)
         assert not question.is_empty
 
 
@@ -939,12 +951,14 @@ class TestRadiosSummary(TestTextSummary):
 
         return ContentQuestion(data)
 
-    def test_value_returns_matching_option_label(self):
-        question = self.question().summary({'example': 'value1'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_returns_matching_option_label(self, summary_inplace_allowed):
+        question = self.question().summary({'example': 'value1'}, inplace_allowed=summary_inplace_allowed)
         assert question.value == 'Option label'
 
-    def test_filter_value_returns_matching_option_filter_label(self):
-        question = self.question().summary({'example': 'value1'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_filter_value_returns_matching_option_filter_label(self, summary_inplace_allowed):
+        question = self.question().summary({'example': 'value1'}, inplace_allowed=summary_inplace_allowed)
         assert question.filter_value == 'option filter label'
 
 
@@ -963,35 +977,45 @@ class TestCheckboxesSummary(QuestionSummaryTest):
 
         return ContentQuestion(data)
 
-    def test_value(self):
-        question = self.question().summary({'example': ['value1', 'value2']})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value(self, summary_inplace_allowed):
+        question = self.question().summary({'example': ['value1', 'value2']}, inplace_allowed=summary_inplace_allowed)
         assert question.value == ['Option label', 'Other label']
 
-    def test_filter_value(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_filter_value(self, summary_inplace_allowed):
         question = self.question().summary({'example': ['value1', 'value2']})
         assert question.filter_value == ['option filter label', 'Other label']
 
-    def test_reading_properties_does_not_mutate_underlying_list_data(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_reading_properties_does_not_mutate_underlying_list_data(self, summary_inplace_allowed):
         # We don't want reading a property such as "value" to change the underlying list, as that would mean subsequent
         # reads of other properties will not work as expected
-        question = self.question().summary({'example': ['value1', 'value2']})
+        question = self.question().summary({'example': ['value1', 'value2']}, inplace_allowed=summary_inplace_allowed)
         assert question.value == ['Option label', 'Other label']
         assert question.filter_value == ['option filter label', 'Other label']
         assert question.value == ['Option label', 'Other label']
         assert question.filter_value == ['option filter label', 'Other label']
 
-    def test_value_with_assurance(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_with_assurance(self, summary_inplace_allowed):
         question = self.question(assuranceApproach='2answers-type1').summary(
-            {'example': {'assurance': 'assurance value', 'value': ['value1', 'value2']}}
+            {'example': {'assurance': 'assurance value', 'value': ['value1', 'value2']}},
+            inplace_allowed=summary_inplace_allowed,
         )
         assert question.value == ['Option label', 'Other label']
 
-    def test_value_with_before_summary_value(self):
-        question = self.question(before_summary_value=['value0']).summary({'example': ['value1', 'value2']})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_with_before_summary_value(self, summary_inplace_allowed):
+        question = self.question(before_summary_value=['value0']).summary(
+            {'example': ['value1', 'value2']},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == ['value0', 'Option label', 'Other label']
 
-    def test_value_with_before_summary_value_if_empty(self):
-        question = self.question(before_summary_value=['value0']).summary({})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_with_before_summary_value_if_empty(self, summary_inplace_allowed):
+        question = self.question(before_summary_value=['value0']).summary({}, inplace_allowed=summary_inplace_allowed)
         assert question.value == ['value0']
 
 
@@ -1026,8 +1050,12 @@ class TestCheckboxTreeSummary(QuestionSummaryTest):
 
         return ContentQuestion(data)
 
-    def test_value(self):
-        question = self.question().summary({'example': ['val1.1', 'val2.2', 'val4']})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value(self, summary_inplace_allowed):
+        question = self.question().summary(
+            {'example': ['val1.1', 'val2.2', 'val4']},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == [
             {
                 "label": "Option 1",
@@ -1044,8 +1072,9 @@ class TestCheckboxTreeSummary(QuestionSummaryTest):
             }
         ]
 
-    def test_value_missing(self):
-        question = self.question().summary({})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_missing(self, summary_inplace_allowed):
+        question = self.question().summary({}, inplace_allowed=summary_inplace_allowed)
         assert question.value == []
 
 
@@ -1059,42 +1088,61 @@ class TestNumberSummary(QuestionSummaryTest):
 
         return ContentQuestion(data)
 
-    def test_value(self):
-        question = self.question().summary({'example': 23.41})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value(self, summary_inplace_allowed):
+        question = self.question().summary({'example': 23.41}, inplace_allowed=summary_inplace_allowed)
         assert question.value == 23.41
 
-    def test_value_zero(self):
-        question = self.question().summary({'example': 0})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_zero(self, summary_inplace_allowed):
+        question = self.question().summary({'example': 0}, inplace_allowed=summary_inplace_allowed)
         assert question.value == 0
 
-    def test_value_without_unit(self):
-        question = self.question().summary({'example': '12.20'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_without_unit(self, summary_inplace_allowed):
+        question = self.question().summary({'example': '12.20'}, inplace_allowed=summary_inplace_allowed)
         assert question.value == '12.20'
 
-    def test_value_adds_unit_before(self):
-        question = self.question(unit=u"£", unit_position="before").summary({'example': '12.20'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_adds_unit_before(self, summary_inplace_allowed):
+        question = self.question(unit=u"£", unit_position="before").summary(
+            {'example': '12.20'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == u'£12.20'
 
-    def test_value_adds_unit_after(self):
-        question = self.question(unit=u"£", unit_position="after").summary({'example': '12.20'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_adds_unit_after(self, summary_inplace_allowed):
+        question = self.question(unit=u"£", unit_position="after").summary(
+            {'example': '12.20'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == u'12.20£'
 
-    def test_value_doesnt_add_unit_if_value_is_empty(self):
-        question = self.question(unit=u"£", unit_position="after").summary({})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_doesnt_add_unit_if_value_is_empty(self, summary_inplace_allowed):
+        question = self.question(unit=u"£", unit_position="after").summary(
+            {},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == u''
 
-    def test_value_adds_unit_for_questions_with_assertion(self):
-        question = self.question(unit=u"£", unit_position="after", assuranceApproach="2answers-type1").summary({
-            'example': {'value': 15, 'assurance': 'Service provider assertion'}
-        })
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_adds_unit_for_questions_with_assertion(self, summary_inplace_allowed):
+        question = self.question(unit=u"£", unit_position="after", assuranceApproach="2answers-type1").summary(
+            {'example': {'value': 15, 'assurance': 'Service provider assertion'}},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == u'15£'
 
-    def test_answer_required(self):
-        question = self.question().summary({'example': 0})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_required(self, summary_inplace_allowed):
+        question = self.question().summary({'example': 0}, inplace_allowed=summary_inplace_allowed)
         assert not question.answer_required
 
-    def test_is_empty(self):
-        question = self.question().summary({'example': 0})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_is_empty(self, summary_inplace_allowed):
+        question = self.question().summary({'example': 0}, inplace_allowed=summary_inplace_allowed)
         assert not question.is_empty
 
 
@@ -1116,37 +1164,58 @@ class TestPricingSummary(QuestionSummaryTest):
 
         return ContentQuestion(data)
 
-    def test_value(self):
-        question = self.question().summary({'priceMin': '20.41', 'priceMax': '25.00'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value(self, summary_inplace_allowed):
+        question = self.question().summary(
+            {'priceMin': '20.41', 'priceMax': '25.00'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == u'£20.41 to £25.00'
 
-    def test_value_without_price_min(self):
-        question = self.question().summary({'priceMax': '25.00'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_without_price_min(self, summary_inplace_allowed):
+        question = self.question().summary({'priceMax': '25.00'}, inplace_allowed=summary_inplace_allowed)
         assert question.value == ''
 
-    def test_value_price_field(self):
-        question = self.question().summary({'price': '20.41'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_price_field(self, summary_inplace_allowed):
+        question = self.question().summary({'price': '20.41'}, inplace_allowed=summary_inplace_allowed)
         assert question.value == u'£20.41'
 
-    def test_value_without_price_max(self):
-        question = self.question().summary({'priceMin': '20.41'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_without_price_max(self, summary_inplace_allowed):
+        question = self.question().summary({'priceMin': '20.41'}, inplace_allowed=summary_inplace_allowed)
         assert question.value == u'£20.41'
 
-    def test_value_with_hours_for_price(self):
-        question = self.question().summary({'priceMin': '20.41', 'priceHours': '8'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_with_hours_for_price(self, summary_inplace_allowed):
+        question = self.question().summary(
+            {'priceMin': '20.41', 'priceHours': '8'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == u'8 for £20.41'
 
-    def test_value_with_unit(self):
-        question = self.question().summary({'priceMin': '20.41', 'priceMax': '25.00', 'priceUnit': 'service'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_with_unit(self, summary_inplace_allowed):
+        question = self.question().summary(
+            {'priceMin': '20.41', 'priceMax': '25.00', 'priceUnit': 'service'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == u'£20.41 to £25.00 per service'
 
-    def test_value_with_interval(self):
-        question = self.question().summary({'priceMin': '20.41', 'priceMax': '25.00', 'priceInterval': 'day'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_with_interval(self, summary_inplace_allowed):
+        question = self.question().summary(
+            {'priceMin': '20.41', 'priceMax': '25.00', 'priceInterval': 'day'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == u'£20.41 to £25.00 per day'
 
-    def test_value_with_unit_and_interval(self):
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_with_unit_and_interval(self, summary_inplace_allowed):
         question = self.question().summary(
-            {'priceMin': '20.41', 'priceMax': '25.00', 'priceUnit': 'service', 'priceInterval': 'day'}
+            {'priceMin': '20.41', 'priceMax': '25.00', 'priceUnit': 'service', 'priceInterval': 'day'},
+            inplace_allowed=summary_inplace_allowed,
         )
         assert question.value == u'£20.41 to £25.00 per service per day'
 
@@ -1189,52 +1258,88 @@ class TestMultiquestionSummary(QuestionSummaryTest):
 
         return ContentQuestion(data)
 
-    def test_value(self):
-        question = self.question().summary({'example2': 'value2', 'example3': 'value3'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value(self, summary_inplace_allowed):
+        question = self.question().summary(
+            {'example2': 'value2', 'example3': 'value3'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.value == question.questions
 
-    def test_value_missing(self):
-        question = self.question().summary({})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_missing(self, summary_inplace_allowed):
+        question = self.question().summary({}, inplace_allowed=summary_inplace_allowed)
         assert question.value == []
 
-    def test_answer_required(self):
-        question = self.question().summary({'example2': 'value2', 'example3': 'value3'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_required(self, summary_inplace_allowed):
+        question = self.question().summary(
+            {'example2': 'value2', 'example3': 'value3'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert not question.answer_required
 
-    def test_is_empty(self):
-        question = self.question().summary({'example': 'value2', 'example3': 'value3'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_is_empty(self, summary_inplace_allowed):
+        question = self.question().summary(
+            {'example': 'value2', 'example3': 'value3'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert not question.is_empty
 
-    def test_answer_required_partial(self):
-        question = self.question().summary({'example3': 'value3'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_required_partial(self, summary_inplace_allowed):
+        question = self.question().summary({'example3': 'value3'}, inplace_allowed=summary_inplace_allowed)
         assert question.answer_required
 
-    def test_is_empty_partial(self):
-        question = self.question().summary({'example2': 'value2'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_is_empty_partial(self, summary_inplace_allowed):
+        question = self.question().summary({'example2': 'value2'}, inplace_allowed=summary_inplace_allowed)
         assert not question.is_empty
 
-    def test_answer_required_if_question_with_followups_not_answered(self):
-        question = self.question_with_followups().summary({'q2': 'blah'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_required_if_question_with_followups_not_answered(self, summary_inplace_allowed):
+        question = self.question_with_followups().summary({'q2': 'blah'}, inplace_allowed=summary_inplace_allowed)
         assert question.answer_required
 
-    def test_answer_required_if_followup_not_answered(self):
-        question = self.question_with_followups().summary({'q2': 'blah', 'q3': True})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_required_if_followup_not_answered(self, summary_inplace_allowed):
+        question = self.question_with_followups().summary(
+            {'q2': 'blah', 'q3': True},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.answer_required
 
-    def test_answer_not_required_if_followups_not_required(self):
-        question = self.question_with_followups().summary({'q2': 'blah', 'q3': False})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_not_required_if_followups_not_required(self, summary_inplace_allowed):
+        question = self.question_with_followups().summary(
+            {'q2': 'blah', 'q3': False},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert not question.answer_required
 
-    def test_answer_required_if_followups_to_followup_not_answered(self):
-        question = self.question_with_followups().summary({'q2': 'blah', 'q3': True, 'q5': 'one'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_required_if_followups_to_followup_not_answered(self, summary_inplace_allowed):
+        question = self.question_with_followups().summary(
+            {'q2': 'blah', 'q3': True, 'q5': 'one'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert question.answer_required
 
-    def test_answer_not_required_if_followups_to_followup_not_required(self):
-        question = self.question_with_followups().summary({'q2': 'blah', 'q3': True, 'q5': 'two'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_not_required_if_followups_to_followup_not_required(self, summary_inplace_allowed):
+        question = self.question_with_followups().summary(
+            {'q2': 'blah', 'q3': True, 'q5': 'two'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert not question.answer_required
 
-    def test_answer_not_required_if_optional_followups_not_answered(self):
-        question = self.question_with_followups().summary({'q2': 'blah', 'q3': True, 'q5': 'one', 'q6': 'blah'})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_answer_not_required_if_optional_followups_not_answered(self, summary_inplace_allowed):
+        question = self.question_with_followups().summary(
+            {'q2': 'blah', 'q3': True, 'q5': 'one', 'q6': 'blah'},
+            inplace_allowed=summary_inplace_allowed,
+        )
         assert not question.answer_required
 
 
@@ -1262,6 +1367,7 @@ class TestDynamicListSummary(QuestionSummaryTest):
 
         return ContentQuestion(data).filter({'context': {'field': ['First Need', 'Second Need', 'Third Need']}})
 
-    def test_value_missing(self):
-        question = self.question().summary({})
+    @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
+    def test_value_missing(self, summary_inplace_allowed):
+        question = self.question().summary({}, inplace_allowed=summary_inplace_allowed)
         assert question.value == []


### PR DESCRIPTION
https://trello.com/c/ooTuJDCw

On my machine,when using the `inplace_allowed` options, this runs the test workload mentioned in https://trello.com/c/RsEEo4So in about 0.59x the time current `master` does.

The bulk of the speedup here comes from new `inplace_allowed` options for `.filter()` and `.summary()`. I'd previously observed that a lot of the time spent in the content loader during normal usage patterns is spent performing deep copy upon deep copy of itself. Currently `.filter()` and `.summary()` calls will return an altered deep-ish copy of themselves ("deep-ish" because it's worse in some places than others). An extremely common usage pattern of the loader however is to call e.g.

```
content_loader.get_manifest("foo").filter(service).summary(service)
```

with each of `get_manifest`, `filter`, and `summary` performing a deep copy of their own. This is very wasteful, because in this sort of call chain, the existing objects are being discarded. So really there's no need to be making sure changes only get applied to the copy that's being returned. Once `get_manifest` has given us its deep copy, we should be satisfied that we have an independent copy of this data that we can mutate as we like.

So the new `inplace_allowed` flag on `.filter()` and `.summary()` lifts this restriction, allowing these methods to operate on (and return) _themselves_. It can be used as and when the caller deems it suitable, but I suspect this will actually be _many_ places in our code.

Note that this argument is called `_allowed` - it doesn't guarantee that the implementation being called will actually mutate itself - there are many cases where it makes no sense to do so. So when using this flag, the original object being called should be discarded and only the return value used, because there's guarantee of which state the object will now be in.

I've gone a bit overboard on the testing for this and turned almost every test which calls either `.filter()` or `.summary()` into a parametrized test, testing both modes.

Other smaller improvements contribute less but are still measurable. They mostly come from intra-function optimizations in very hot paths. Commit comments tell you more...