### PR TITLE
markdown: add GOVUKFrontendExtension to apply govuk-frontend classes to generated elements

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.3.0'
+__version__ = '7.4.0'

--- a/dmcontent/markdown.py
+++ b/dmcontent/markdown.py
@@ -1,0 +1,44 @@
+from typing import Mapping
+from xml.etree.ElementTree import Element
+
+from markdown.extensions import Extension
+from markdown.treeprocessors import Treeprocessor
+
+
+class _ClassAddingTreeprocessor(Treeprocessor):
+    _mapping: Mapping[str, str]
+
+    def __init__(self, mapping: Mapping[str, str]):
+        self._mapping = mapping
+
+    def run(self, root: Element):
+        self._run(root)
+
+    def _run(self, element: Element):
+        # recurse
+        for child in element:
+            self._run(child)
+
+        # mutate each affected element in-place
+        if element.tag in self._mapping:
+            orig_class = element.attrib.get("class", "")
+            element.set("class", (orig_class + " " if orig_class else "") + self._mapping[element.tag])
+
+
+class GOVUKFrontendExtension(Extension):
+    """
+    Markdown extension adding govuk-frontend classes to generated paragraphs and lists (note - will not affect
+    manual html)
+    """
+    GOVUK_ELEMENT_CLASSES = {
+        "p": "govuk-body",
+        "ul": "govuk-list govuk-list--bullet",
+        "ol": "govuk-list govuk-list--number",
+    }
+
+    def extendMarkdown(self, md, md_globals):
+        # NOTE the interface for registering extensions is much improved after Markdown 3.0.0. TODO upgrade.
+        md.registerExtension(self)
+        self.processor = _ClassAddingTreeprocessor(self.GOVUK_ELEMENT_CLASSES)
+        self.processor.md = md
+        md.treeprocessors["govukfrontendclassadder"] = self.processor

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -2,12 +2,13 @@ import collections
 import typing
 
 from jinja2 import Markup, StrictUndefined, TemplateSyntaxError, UndefinedError
-from markdown import markdown
+from markdown import Markdown
 
 from dmutils.jinja2_environment import DMSandboxedEnvironment
 from dmcontent.errors import ContentNotFoundError
 
 from .errors import ContentTemplateError
+from .markdown import GOVUKFrontendExtension
 
 
 if typing.TYPE_CHECKING:
@@ -38,6 +39,8 @@ class _ImmutableTemplateProxy:
 
 
 class TemplateField(object):
+    markdown_instance = Markdown(extensions=[GOVUKFrontendExtension()])
+
     def __init__(self, field_value, markdown=None):
         self.source = field_value
 
@@ -52,7 +55,7 @@ class TemplateField(object):
             raise ContentTemplateError(e.message)
 
     def make_template(self, field_value):
-        template = markdown(field_value) if self.markdown else field_value
+        template = self.markdown_instance.convert(field_value) if self.markdown else field_value
 
         return _ImmutableTemplateProxy(template_environment.from_string(template))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,7 @@ class TestTemplateField(object):
 
     def test_template_field_with_force_markdown(self):
         field = TemplateField('Hello *world*', markdown=True)
-        assert field.render() == '<p>Hello <em>world</em></p>'
+        assert field.render() == '<p class="govuk-body">Hello <em>world</em></p>'
 
     def test_template_renders_as_markup(self):
         field = TemplateField('simple template')
@@ -87,12 +87,31 @@ class TestTemplateField(object):
     def test_fields_are_processed_with_markdown(self):
         field = TemplateField(u'# Title\n* Hello\n* Markdown')
 
-        assert field.render() == '<h1>Title</h1>\n<ul>\n<li>Hello</li>\n<li>Markdown</li>\n</ul>'
+        assert field.render() == """<h1>Title</h1>
+<ul class="govuk-list govuk-list--bullet">
+<li>Hello</li>
+<li>Markdown</li>
+</ul>"""
 
     def test_simple_strings_are_not_wrapped_in_paragraph_tags(self):
         field = TemplateField(u'Title string')
 
         assert field.render() == 'Title string'
+
+    def test_markdown_strings_govuk_classes(self):
+        field = TemplateField(u'Some paragraph\n\n * Some\n * List\n\nAnd\n\n1. Some other\n2. Ordered\n3. List & such')
+
+        assert field.render() == """<p class="govuk-body">Some paragraph</p>
+<ul class="govuk-list govuk-list--bullet">
+<li>Some</li>
+<li>List</li>
+</ul>
+<p class="govuk-body">And</p>
+<ol class="govuk-list govuk-list--number">
+<li>Some other</li>
+<li>Ordered</li>
+<li>List &amp; such</li>
+</ol>"""
 
     def test_jinja_markdown_errors_raise_an_exception(self):
         with pytest.raises(ContentTemplateError):
@@ -120,7 +139,7 @@ class TestTemplateFieldsInTemplate(object):
         rendered_field = TemplateField(template_string).render({'name': 'context'})
         final_template = env.from_string('{{ rendered_field }}').render({'rendered_field': rendered_field})
 
-        assert final_template == '<p>This <em>is</em> a context <em>template</em></p>'
+        assert final_template == '<p class="govuk-body">This <em>is</em> a context <em>template</em></p>'
 
     def test_jinja_in_field_variables_is_not_evaluated(self):
         env = Environment(autoescape=True)
@@ -144,7 +163,7 @@ class TestTemplateFieldsInTemplate(object):
         rendered_field = TemplateField(template_string).render({'name': 'context'})
         final_template = env.from_string('{{ rendered_field|safe }}').render({'rendered_field': rendered_field})
 
-        assert final_template == '<p>This <em>is</em> a context <em>template</em></p>'
+        assert final_template == '<p class="govuk-body">This <em>is</em> a context <em>template</em></p>'
 
     def test_jinja_in_field_variables_is_not_evaluated_with_safe(self):
         env = Environment(autoescape=True)


### PR DESCRIPTION
https://trello.com/c/scaNu2Aq

What do people think? To me, doing this seems less scary than keeping half of our content fields as fully-escaped html.

~Haven't tried this in a frontend yet.~