### PR TITLE
Add html module to format questions for display

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.4.0'
+__version__ = '7.5.0'

--- a/dmcontent/html.py
+++ b/dmcontent/html.py
@@ -1,0 +1,140 @@
+"""
+Code to format content summary values as HTML.
+
+This module has two main functions:
+
+    to_html(): Format the value of a QuestionSummary as HTML.
+    to_summary_list_rows(): Turn a collection of QuestionSummarys into
+                            rows for govukSummaryList.
+
+The logic for how to format values is based on that in the deprecated
+digitalmarketplace-frontend-toolkit, specifically the summary content macros in
+`templates/summary-content.html`.
+
+Note: this code doesn't provide for formatting of assurance approach
+information, as that hasn't been used since G-Cloud 8.
+"""
+
+from typing import List
+
+from jinja2 import Markup, escape
+
+from dmutils.filters import capitalize_first, format_links, replace_newlines_with_breaks
+
+
+def to_html(
+    question_summary, *, capitalize_first: bool = False, format_links: bool = False
+) -> Markup:
+    """Format the value of a QuestionSummary as HTML.
+
+    :param bool capitalize_first: If True, the first letter of any text will be capitalized
+    :param bool format_links: If True any HTTP URLs in any text will be turned into HTML <a> elements
+    """
+    kwargs = {
+        "capitalize_first": capitalize_first,
+        "format_links": format_links,
+    }
+
+    # Duck type the value of question_summary
+    question_type = None
+    try:
+        question_type = question_summary["type"]
+    except TypeError:
+        raise TypeError("to_html() expects a QuestionSummary")
+
+    # filter_value falls back to value if the question doesn't have any
+    # filter_label properties, so we can use filter_value safely in
+    # all cases.
+    question_value = question_summary.filter_value
+
+    if question_type == "boolean":
+        return boolean_to_html(question_value)
+    elif question_type == "number":
+        return number_to_html(question_value)
+    elif question_type == "list":
+        return list_to_html(question_value, **kwargs)
+    elif question_type == "checkboxes":
+        return list_to_html(question_value)
+    elif question_type == "boolean_list":
+        return boolean_list_to_html(question_value)
+    elif question_type == "multiquestion":
+        return multiquestion_to_html(question_summary)
+    elif question_type == "upload":
+        return upload_to_html(question_summary)
+    elif question_type == "textbox_large":
+        return text_to_html(question_value, preserve_line_breaks=True, **kwargs)
+    else:
+        return text_to_html(question_value, **kwargs)
+
+
+def to_summary_list_rows(questions) -> List[dict]:
+    """Convert a collection of QuestionSummarys into rows for govukSummaryList.
+
+    This method expects that each question in `questions` is a
+    QuestionSummary i.e. each question includes service data.
+    """
+    return [
+        {"key": {"text": question.label}, "value": {"html": to_html(question)}}
+        for question in questions
+        if not question.is_empty
+    ]
+
+
+def text_to_html(value, **kwargs):
+    if "capitalize_first" in kwargs:
+        value = capitalize_first(value)
+
+    if "format_links" in kwargs:
+        value = format_links(value)
+
+    if "preserve_line_breaks" in kwargs:
+        # replace_newlines_with_breaks escapes its input anyway
+        # so wrapping with Markup here is fine.
+        value = Markup(replace_newlines_with_breaks(value))
+
+    return escape(value)
+
+
+def list_to_html(value, **kwargs):
+    lines = ['<ul class="govuk-list govuk-list--bullet">']
+    for item in value:
+        lines.append(f"  <li>{text_to_html(item, **kwargs)}</li>")
+    lines.append("</ul>")
+    html = "\n".join(lines)
+    return Markup(html)
+
+
+def boolean_to_html(value):
+    if value is True:
+        return text_to_html("Yes")
+    if value is False:
+        return text_to_html("No")
+
+
+def boolean_list_to_html(value_list):
+    html_values = []
+    for value in value_list:
+        html_values.append(boolean_to_html(value))
+    return list_to_html(html_values)
+
+
+def number_to_html(value):
+    return text_to_html(str(value))
+
+
+def upload_to_html(question):
+    return Markup(f'<a class="govuk-link" href="{question.filter_value}">{question.label}</a>')
+
+
+def multiquestion_to_html(summary):
+    lines = []
+    for index, question in enumerate(summary.questions):
+        if not question.is_empty:
+            if (index == 0):
+                classes = "govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-1"
+            else:
+                classes = "govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-1"
+            lines.append(f'<p class="{classes}">{escape(question.label)}</p>')
+            lines.append(f'<div>{to_html(question)}</div>')
+    html = "\n".join(lines)
+    return Markup(html)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -e .
 # DON'T FORGET TO UPDATE setup.py !!
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.2.0#egg=digitalmarketplace-utils==52.2.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'Markdown<3.0.0,>=2.6.7',
         'PyYAML<6.0,>=5.1.2',
         'inflection<1.0.0,>=0.3.1',
-        'digitalmarketplace-utils>=50.0.1',
+        'digitalmarketplace-utils>=52.2.0',
     ],
     python_requires="~=3.6",
 )

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,436 @@
+from textwrap import dedent
+
+import jinja2
+import pytest
+from jinja2 import Markup
+
+from dmcontent.content_loader import ContentManifest
+from dmcontent.html import to_html, to_summary_list_rows
+
+
+@pytest.fixture
+def content_summary():
+    content = ContentManifest(
+        [
+            {
+                "slug": "first_section",
+                "name": "First Section",
+                "questions": [
+                    {
+                        "id": "myBooleanTrue",
+                        "type": "boolean",
+                        "label": "Boolean question with answer True",
+                    },
+                    {
+                        "id": "myBooleanFalse",
+                        "type": "boolean",
+                        "label": "Boolean question with answer False",
+                    },
+                    {
+                        "id": "myBooleanList",
+                        "type": "boolean_list",
+                        "label": "Boolean list question",
+                    },
+                    {
+                        "id": "myCheckbox",
+                        "type": "checkboxes",
+                        "label": "Checkboxes question",
+                    },
+                    {"id": "myDate", "type": "date", "label": "Date question"},
+                    {
+                        "id": "myEmptyString",
+                        "type": "text",
+                        "question": "Text question with empty answer",
+                    },
+                    {
+                        "id": "myFloat",
+                        "type": "number",
+                        "question": "Numeric question with decimal answer",
+                    },
+                    {
+                        "id": "myInteger",
+                        "type": "number",
+                        "question": "Numeric question with integer answer",
+                    },
+                    {
+                        "id": "myMultiquestion",
+                        "type": "multiquestion",
+                        "label": "Multiquestion",
+                        "questions": [
+                            {"id": "mq01", "type": "text", "label": "MQ One"},
+                            {"id": "mq02", "type": "text", "question": "MQ Two"},
+                        ],
+                    },
+                    {
+                        "id": "myPricing",
+                        "type": "pricing",
+                        "label": "Pricing question",
+                        "fields": {
+                            "minimum_price": "pricing.min",
+                            "maximum_price": "pricing.max",
+                        },
+                    },
+                    {"id": "myRadio", "type": "radios", "label": "Radio button question"},
+                    {"id": "mySimpleList", "type": "list", "label": "List question"},
+                    {"id": "mySimpleText", "type": "text", "label": "Text question"},
+                    {
+                        "id": "myLinkText",
+                        "type": "text",
+                        "label": "Text question with a link in the answer",
+                    },
+                    {
+                        "id": "myLinkTextarea",
+                        "type": "textbox_large",
+                        "label": "Text question with multiple lines and a link in the answer",
+                    },
+                    {
+                        "id": "myLinkList",
+                        "type": "list",
+                        "label": "List question with links in the answer",
+                    },
+                    {
+                        "id": "myLowercaseText",
+                        "type": "text",
+                        "label": "Text question with a lower-case answer",
+                    },
+                    {
+                        "id": "myLowercaseTextarea",
+                        "type": "textbox_large",
+                        "question": "Text question with multiple lines and a lower-case answer",
+                    },
+                    {
+                        "id": "myLowercaseList",
+                        "type": "list",
+                        "label": "List question with a lower-case answer",
+                    },
+                    {
+                        "id": "myMultipleLines",
+                        "type": "textbox_large",
+                        "question": "Text question with multiple lines in the answer",
+                    },
+                    {"id": "myUpload", "type": "upload", "question": "Upload Question"},
+                    {
+                        "id": "myScriptInjection",
+                        "type": "text",
+                        "label": "Text question with HTML in the answer",
+                    },
+                    {
+                        "id": "myUnansweredQuestion",
+                        "type": "text",
+                        "optional": True,
+                        "label": "Optional question which is not answered",
+                    },
+                    {
+                        "id": "myMultiquestionWithMultipleTypes",
+                        "type": "multiquestion",
+                        "label": "Multiquestion",
+                        "questions": [
+                            {"id": "mqText", "type": "text", "label": "Text question"},
+                            {"id": "mqList", "type": "list", "question": "List question"},
+                            {"id": "mqCheckbox", "type": "checkboxes", "question": "Checkbox question"},
+                            {"id": "mqBoolean", "type": "boolean", "question": "Boolean question"},
+                            {"id": "mqBooleanList", "type": "boolean_list", "question": "Boolean list question"},
+                            {"id": "mqRadio", "type": "radios", "question": "Radios question"},
+                            {"id": "mqUnanswered", "type": "text", "optional": True, "label": "Unanswered question"},
+                            {"id": "mqUpload", "type": "upload", "question": "Upload question"}
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
+    return content.summary(
+        {
+            "myBooleanTrue": True,
+            "myBooleanFalse": False,
+            "myDate": "2016-02-18",
+            "mySimpleText": "Hello World",
+            "myInteger": 7,
+            "myFloat": 23.45,
+            "mySimpleList": ["Hello", "World"],
+            "myRadio": "Selected radio value",
+            "mq01": "Multiquestion answer 1",
+            "mq02": "Multiquestion answer 2",
+            "mqBoolean": True,
+            "mqBooleanList": [True, False],
+            "mqCheckbox": ["Check 1", "Check 2"],
+            "mqList": ["Hello", "World"],
+            "mqRadio": "Selected radio value",
+            "mqText": "Multiquestion text answer",
+            "mqUpload": "#",
+            "myCheckbox": ["Check 1", "Check 2"],
+            "myBooleanList": [True, False, False, True],
+            "myUpload": "#",
+            "myLinkText": "https://www.gov.uk",
+            "myLinkTextarea": "Here is a URL:\r\n\r\nhttps://www.gov.uk",
+            "myLinkList": ["https://www.gov.uk", "https://www.gov.uk/"],
+            "myLowercaseText": "text to be capitalised",
+            "myLowercaseTextarea": "text to be capitalised\r\nwith a line break.",
+            "myLowercaseList": ["line 1", "line 2"],
+            "pricing.min": "20.41",
+            "pricing.max": "25.00",
+            "myMultipleLines": "Text with multiple lines.\r\n\r\nThis is the second line.",
+            "myScriptInjection": "<script>do something bad</script>"
+        }
+    )
+
+
+def test_to_html_raises_error_if_value_is_not_valid():
+    with pytest.raises(TypeError):
+        to_html(None)
+
+
+def test_to_html_returns_value(content_summary):
+    question = content_summary.get_question("myEmptyString")
+    assert to_html(question) == ""
+
+
+def test_to_html_returns_yes_if_boolean_true(content_summary):
+    question = content_summary.get_question("myBooleanTrue")
+    assert to_html(question) == "Yes"
+
+
+def test_to_html_returns_no_if_boolean_false(content_summary):
+    question = content_summary.get_question("myBooleanFalse")
+    assert to_html(question) == "No"
+
+
+def test_to_html_returns_text_as_html(content_summary):
+    question = content_summary.get_question("mySimpleText")
+    assert to_html(question) == "Hello World"
+
+
+def test_to_html_returns_text_for_number(content_summary):
+    integer_question = content_summary.get_question("myInteger")
+    float_question = content_summary.get_question("myFloat")
+    assert to_html(integer_question) == "7"
+    assert to_html(float_question) == "23.45"
+
+
+def test_to_html_returns_html_if_question_type_is_multiquestion(content_summary):
+    question = content_summary.get_question("myMultiquestion")
+    expected = dedent(
+        """\
+    <p class="govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-1">MQ One</p>
+    <div>Multiquestion answer 1</div>
+    <p class="govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-1">MQ Two</p>
+    <div>Multiquestion answer 2</div>"""
+    )
+    assert to_html(question) == expected
+
+
+def test_to_html_returns_html_with_multiquestion_sub_types(content_summary):
+    question = content_summary.get_question("myMultiquestionWithMultipleTypes")
+    expected = dedent(
+        """\
+    <p class="govuk-body govuk-!-margin-top-0 govuk-!-margin-bottom-1">Text question</p>
+    <div>Multiquestion text answer</div>
+    <p class="govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-1">List question</p>
+    <div><ul class="govuk-list govuk-list--bullet">
+      <li>Hello</li>
+      <li>World</li>
+    </ul></div>
+    <p class="govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-1">Checkbox question</p>
+    <div><ul class="govuk-list govuk-list--bullet">
+      <li>Check 1</li>
+      <li>Check 2</li>
+    </ul></div>
+    <p class="govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-1">Boolean question</p>
+    <div>Yes</div>
+    <p class="govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-1">Boolean list question</p>
+    <div><ul class="govuk-list govuk-list--bullet">
+      <li>Yes</li>
+      <li>No</li>
+    </ul></div>
+    <p class="govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-1">Radios question</p>
+    <div>Selected radio value</div>
+    <p class="govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-1">Upload question</p>
+    <div><a class="govuk-link" href="#">Upload question</a></div>"""
+    )
+    assert to_html(question) == expected
+
+
+def test_to_html_returns_html_list_if_question_type_is_list(content_summary):
+    list_question = content_summary.get_question("mySimpleList")
+    expected = dedent(
+        """\
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Hello</li>
+      <li>World</li>
+    </ul>"""
+    )
+
+    assert to_html(list_question) == expected
+
+
+def test_to_html_returns_html_list_if_question_type_is_boolean_list(content_summary):
+    boolean_list_question = content_summary.get_question("myBooleanList")
+    expected = dedent(
+        """\
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Yes</li>
+      <li>No</li>
+      <li>No</li>
+      <li>Yes</li>
+    </ul>"""
+    )
+
+    assert to_html(boolean_list_question) == expected
+
+
+def test_to_html_returns_text_if_question_type_is_radios(content_summary):
+    question = content_summary.get_question("myRadio")
+    assert to_html(question) == "Selected radio value"
+
+
+def test_to_html_returns_html_list_if_question_type_is_checkboxes(content_summary):
+    integer_question = content_summary.get_question("myCheckbox")
+    expected = dedent(
+        """\
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Check 1</li>
+      <li>Check 2</li>
+    </ul>"""
+    )
+
+    assert to_html(integer_question) == expected
+
+
+def test_to_html_returns_text_for_date_question(content_summary):
+    question = content_summary.get_question("myDate")
+
+    assert to_html(question) == "Thursday 18 February 2016"
+
+
+def test_to_html_returns_text_for_pricing_question(content_summary):
+    question = content_summary.get_question("myPricing")
+
+    assert to_html(question) == "£20.41 to £25.00"
+
+
+def test_to_html_returns_wrapped_anchor_if_question_type_is_upload(content_summary):
+    question = content_summary.get_question("myUpload")
+    assert to_html(question) == '<a class="govuk-link" href="#">Upload Question</a>'
+
+
+def test_to_html_preserves_line_breaks_for_textbox_large_questions(content_summary):
+    question = content_summary.get_question("myMultipleLines")
+    assert to_html(question) == Markup(
+        "Text with multiple lines.<br><br>This is the second line."
+    )
+
+
+@pytest.mark.parametrize(
+    "question, expected",
+    [
+        ("myLowercaseText", "Text to be capitalised"),
+        ("myLowercaseTextarea", "Text to be capitalised<br>with a line break."),
+        (
+            "myLowercaseList",
+            """<ul class="govuk-list govuk-list--bullet">\n  <li>Line 1</li>\n  <li>Line 2</li>\n</ul>""",
+        ),
+    ],
+)
+def test_to_html_can_capitalize_first(content_summary, question, expected):
+    question = content_summary.get_question(question)
+    assert to_html(question, capitalize_first=True) == expected
+
+
+@pytest.mark.parametrize(
+    "question, expected",
+    [
+        (
+            "myLinkText",
+            """<a href="https://www.gov.uk" class="app-break-link" rel="external">https://www.gov.uk</a>""",
+        ),
+        (
+            "myLinkTextarea",
+            """Here is a URL:<br><br>"""
+            """<a href="https://www.gov.uk" class="app-break-link" rel="external">https://www.gov.uk</a>""",
+        ),
+        (
+            "myLinkList",
+            dedent(
+                """\
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a href="https://www.gov.uk" class="app-break-link" rel="external">https://www.gov.uk</a></li>
+          <li><a href="https://www.gov.uk/" class="app-break-link" rel="external">https://www.gov.uk/</a></li>
+        </ul>"""
+            ),
+        ),
+    ],
+)
+def test_to_html_can_format_links(content_summary, question, expected):
+    question = content_summary.get_question(question)
+    assert to_html(question, format_links=True) == expected
+
+
+@pytest.mark.parametrize(
+    "question, expected",
+    (
+        ("myUpload", """<a class="govuk-link" href="#">Upload Question</a>"""),
+        ("myScriptInjection", "&lt;script&gt;do something bad&lt;/script&gt;"),
+        (
+            "mySimpleList",
+            dedent(
+                """\
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Hello</li>
+          <li>World</li>
+        </ul>"""
+            ),
+        ),
+    ),
+)
+@pytest.mark.parametrize("autoescape", (True, False))
+def test_to_html_returns_html_which_is_safe_for_jinja(
+    content_summary, question, expected, autoescape
+):
+    question = content_summary.get_question(question)
+    html = to_html(question)
+
+    env = jinja2.Environment(autoescape=autoescape)
+    template = env.from_string("{{ html }}")
+
+    assert template.render(html=html) == expected
+
+
+def test_to_summary_list_rows(content_summary):
+    questions = content_summary.sections[0].questions
+    summary_list_rows = to_summary_list_rows(questions)
+
+    assert len(summary_list_rows) == 22
+    assert all("key" in row and "value" in row for row in summary_list_rows)
+
+    assert summary_list_rows[0] == {
+        "key": {"text": "Boolean question with answer True"},
+        "value": {"html": Markup("Yes")},
+    }
+
+    assert summary_list_rows[11] == {
+        "key": {"text": "Text question"},
+        "value": {"html": Markup("Hello World")},
+    }
+
+    assert summary_list_rows[17] == {
+        "key": {"text": "List question with a lower-case answer"},
+        "value": {
+            "html": Markup(
+                dedent(
+                    """\
+                <ul class="govuk-list govuk-list--bullet">
+                  <li>Line 1</li>
+                  <li>Line 2</li>
+                </ul>"""
+                )
+            )
+        },
+    }
+
+    # optional_question and empty_string are empty, so should not be present
+    assert "Text question with empty answer" not in [
+        row["key"]["text"] for row in summary_list_rows
+    ]
+    assert "Optional question is not answered" not in [
+        row["key"]["text"] for row in summary_list_rows
+    ]


### PR DESCRIPTION
https://trello.com/c/CXGExCLO/55-3-replace-summary-table-with-summary-list-on-g-cloud-service-page-and-dos-opportunity-page

We want to be able to easily display users answers to questions using
the [summary list component](https://design-system.service.gov.uk/components/summary-list/) from the GOV.UK Design System.

To be able to do this we need to turn a collection of QuestionSummary
objects into an list of row objects usable with the `govukSummaryList`
macro.

To achieve this, we have added the `html` module which formats `QuestionSummary` values into HTML and arranges them into a list that can be passed straight into a `{{ govukSummaryList 
 rows={transformed_data} }}` macro.