### PR TITLE
Add href to question objects to fix error summary links

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.6.2'
+__version__ = '7.7.0'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -110,6 +110,7 @@ class Question(object):
 
             question_errors[error_key] = {
                 'input_name': error_key,
+                'href': question.href,
                 'question': getattr(question, question_descriptor_from),
                 'message': validation_message,
             }
@@ -137,6 +138,26 @@ class Question(object):
         }
 
         return defaults.get(message_key, 'There was a problem with the answer to this question.')
+
+    @property
+    def href(self):
+        """Return the URL fragment for the first input element for this question"""
+        # This code unfortunately couples us to the template used to render the question
+        # TODO: be better
+        href = f"#input-{self.id}"
+
+        question_type = self.get("type")
+
+        if question_type in ("checkboxes", "list", "radios"):
+            href = f"{href}-1"
+
+        if question_type == "checkbox_tree":
+            href = f"{href}-1-1"
+
+        if question_type == "date":
+            href = f"{href}-day"
+
+        return href
 
     @property
     def label(self):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -513,16 +513,19 @@ class TestMultiquestion(QuestionTest):
         assert question.get_error_messages(multi_question_form_errors) == OrderedDict([
             ('technicalCompetence', {
                 'input_name': 'technicalCompetence',
+                'href': '#input-technicalCompetence',
                 'message': 'You need to answer this question.',
                 'question': 'Technical Competence'
             }),
             ('price', {
                 'input_name': 'price',
+                'href': '#input-price',
                 'message': 'There was a problem with the answer to this question.',
                 'question': 'Price'
             }),
             ('culturalFit', {
                 'input_name': 'culturalFit',
+                'href': '#input-culturalFit',
                 'message': 'You need to answer this question.',
                 'question': 'Cultural Fit'
             })


### PR DESCRIPTION
https://trello.com/c/qUAR9Nm4/20-1-replace-validation-banner-with-govuk-frontend-error-summary-component-in-the-briefs-frontend