### PR TITLE
Add option to not filter empty answers from summary list rows

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.7.0'
+__version__ = '7.8.0'

--- a/dmcontent/html.py
+++ b/dmcontent/html.py
@@ -67,18 +67,20 @@ def to_html(
         return text_to_html(question_value, **kwargs)
 
 
-def to_summary_list_rows(questions, **kwargs) -> List[dict]:
+def to_summary_list_rows(questions, *, filter_empty=True, **kwargs) -> List[dict]:
     """Convert a collection of QuestionSummarys into rows for govukSummaryList.
 
     This method expects that each question in `questions` is a
     QuestionSummary i.e. each question includes service data.
 
     `kwargs` are passed to `to_html`.
+
+    :param bool filter_empty: Whether or not to include unanswered questions in the rows
     """
     return [
         {"key": {"text": question.label}, "value": {"html": to_html(question, **kwargs)}}
         for question in questions
-        if not question.is_empty
+        if not (question.is_empty and filter_empty)
     ]
 
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -473,3 +473,42 @@ def test_to_summary_list_rows(content_summary):
     assert "Optional question is not answered" not in [
         row["key"]["text"] for row in summary_list_rows
     ]
+
+
+@pytest.mark.parametrize("filter_empty", [True, False])
+def test_to_summary_list_rows_can_include_empty(content_summary, filter_empty):
+    questions = content_summary.sections[0].questions
+    summary_list_rows = to_summary_list_rows(questions, filter_empty=filter_empty)
+
+    # optional_question and empty_string are not answered,
+    # but should still be present when filter_empty is false
+
+    text_question = [
+        row for row in summary_list_rows
+        if row["key"]["text"] == "Text question with empty answer"
+    ]
+
+    if filter_empty is True:
+        assert text_question == []
+    else:
+        assert text_question == [
+            {
+                "key": {"text": "Text question with empty answer"},
+                "value": {"html": ""},
+            }
+        ]
+
+    optional_question = [
+        row for row in summary_list_rows
+        if row["key"]["text"] == "Optional question which is not answered"
+    ]
+
+    if filter_empty is True:
+        assert optional_question == []
+    else:
+        assert optional_question == [
+            {
+                "key": {"text": "Optional question which is not answered"},
+                "value": {"html": ""},
+            }
+        ]


### PR DESCRIPTION
Fixing the functional tests for alphagov/digitalmarketplace-buyer-frontend#1041 with @gidsg we found a change between staging and preview with DOS opportunity details: currently (on production and staging) optional questions that aren’t answered are shown as empty, whereas with the new version (on preview) optional questions that aren’t answered aren’t shown at all.

---

New behaviour on preview, hiding unanswered questions:
![Screenshot of new behaviour on preview, hiding unanswered questions](https://user-images.githubusercontent.com/503614/84153431-c743a100-aa5d-11ea-94bc-c1023265cf89.png)

Old behaviour on staging and production, showing unanswered questions as empty:
![Screenshot of old behaviour on staging and production, showing unanswered questions as empty](https://user-images.githubusercontent.com/503614/84153483-daef0780-aa5d-11ea-8da9-4b8d10873b75.png)

---

@fajerq decided we should restore the old behaviour.

This PR adds a keyword arg `filter_empty` to `to_summary_list_rows` that when `False` will leave unanswered questions in, restoring the old behaviour.