### PR TITLE
Add new tab link option to to_summary_list_rows

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.8.1'
+__version__ = '7.9.0'

--- a/dmcontent/html.py
+++ b/dmcontent/html.py
@@ -23,7 +23,11 @@ import dmutils.filters as filters
 
 
 def to_html(
-    question_summary, *, capitalize_first: bool = False, format_links: bool = False
+    question_summary,
+    *,
+    capitalize_first: bool = False,
+    format_links: bool = False,
+    open_links_in_new_tab: bool = False
 ) -> Markup:
     """Format the value of a QuestionSummary as HTML.
 
@@ -33,6 +37,7 @@ def to_html(
     kwargs = {
         "capitalize_first": capitalize_first,
         "format_links": format_links,
+        "open_links_in_new_tab": open_links_in_new_tab,
     }
 
     # Duck type the value of question_summary
@@ -88,6 +93,7 @@ def text_to_html(
         capitalize_first=False,
         format_links=False,
         preserve_line_breaks=False,
+        open_links_in_new_tab=False,
         **kwargs
 ):
     """Convert a string to a HTML string, optionally modifying it first.
@@ -95,12 +101,13 @@ def text_to_html(
     :param bool capitalize_first: If True, the first letter of any text will be capitalized
     :param bool format_links: If True any HTTP URLs in any text will be turned into HTML <a> elements
     :param bool preserve_line_breaks: If True HTTP newline sequences (\\r\\n) will be turned into HTML <br> elements
+    :param bool open_links_in_new_tab: If True formatted HTTP URL <a> elements will open in a new tab
     """
     if capitalize_first is True:
         value = filters.capitalize_first(value)
 
     if format_links is True:
-        value = filters.format_links(value)
+        value = filters.format_links(value, open_links_in_new_tab)
 
     if preserve_line_breaks is True:
         # replace_newlines_with_breaks escapes its input anyway

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -405,6 +405,38 @@ def test_to_html_can_format_links(content_summary, question, expected):
     assert to_html(question, format_links=True) == expected
 
 
+link_attributes = 'class="app-break-link" rel="external noreferrer noopener" target="_blank"'
+
+
+@pytest.mark.parametrize(
+    "question, expected",
+    [
+        (
+            "myLinkText",
+            f'<a href="https://www.gov.uk" {link_attributes}>https://www.gov.uk</a>'
+        ),
+        (
+            "myLinkTextarea",
+            """Here is a URL:<br><br>"""
+            f'<a href="https://www.gov.uk" {link_attributes}>https://www.gov.uk</a>'
+        ),
+        (
+            "myLinkList",
+            dedent(
+                f"""\
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a href="https://www.gov.uk" {link_attributes}>https://www.gov.uk</a></li>
+          <li><a href="https://www.gov.uk/" {link_attributes}>https://www.gov.uk/</a></li>
+        </ul>"""
+            ),
+        ),
+    ],
+)
+def test_to_html_can_format_links_which_open_in_a_new_tab(content_summary, question, expected):
+    question = content_summary.get_question(question)
+    assert to_html(question, format_links=True, open_links_in_new_tab=True) == expected
+
+
 @pytest.mark.parametrize(
     "question, expected",
     (


### PR DESCRIPTION
On the [Briefs FE preview Brief page](https://github.com/alphagov/digitalmarketplace-briefs-frontend/blob/13a289f2387697f3139158bc2b16b46771b1742f/app/templates/buyers/preview_brief_source.html#L123), we use the property `open_links_in_new_tab`, which we hadn't accounted for.

This adds that property to the HTML script.

Required for https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/321

https://trello.com/c/BpDhnaYa/93-1-preview-dos-opportunity-before-publishing