### PR TITLE
Add govuk-heading and govuk-link classes to anchor and h2 elements

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.9.0'
+__version__ = '7.10.0'

--- a/dmcontent/markdown.py
+++ b/dmcontent/markdown.py
@@ -34,6 +34,7 @@ class GOVUKFrontendExtension(Extension):
         "p": "govuk-body",
         "ul": "govuk-list govuk-list--bullet",
         "ol": "govuk-list govuk-list--number",
+        "a": "govuk-link",
     }
 
     def extendMarkdown(self, md, md_globals):

--- a/dmcontent/markdown.py
+++ b/dmcontent/markdown.py
@@ -35,6 +35,7 @@ class GOVUKFrontendExtension(Extension):
         "ul": "govuk-list govuk-list--bullet",
         "ol": "govuk-list govuk-list--number",
         "a": "govuk-link",
+        "h2": "govuk-heading-m"
     }
 
     def extendMarkdown(self, md, md_globals):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ coverage
 coveralls
 flake8<3.8.0,>=3.7.7
 mock
-pytest>=4.0.0
+pytest>=4.6.0
 pytest-cov

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -100,6 +100,7 @@ class TestTemplateField(object):
 
     def test_markdown_strings_govuk_classes(self):
         field = TemplateField(
+            u'##A Heading\n\n'
             u'Some paragraph\n\n'
             u' * Some\n'
             u' * List\n\n'
@@ -109,7 +110,8 @@ class TestTemplateField(object):
             u'3. List & such'
         )
 
-        assert field.render() == """<p class="govuk-body">Some paragraph</p>
+        assert field.render() == """<h2 class="govuk-heading-m">A Heading</h2>
+<p class="govuk-body">Some paragraph</p>
 <ul class="govuk-list govuk-list--bullet">
 <li>Some</li>
 <li>List</li>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,7 +99,15 @@ class TestTemplateField(object):
         assert field.render() == 'Title string'
 
     def test_markdown_strings_govuk_classes(self):
-        field = TemplateField(u'Some paragraph\n\n * Some\n * List\n\nAnd\n\n1. Some other\n2. Ordered\n3. List & such')
+        field = TemplateField(
+            u'Some paragraph\n\n'
+            u' * Some\n'
+            u' * List\n\n'
+            u'And\n\n'
+            u'1. Some other\n'
+            u'2. [Ordered](http://example.com)\n'
+            u'3. List & such'
+        )
 
         assert field.render() == """<p class="govuk-body">Some paragraph</p>
 <ul class="govuk-list govuk-list--bullet">
@@ -109,7 +117,7 @@ class TestTemplateField(object):
 <p class="govuk-body">And</p>
 <ol class="govuk-list govuk-list--number">
 <li>Some other</li>
-<li>Ordered</li>
+<li><a class="govuk-link" href="http://example.com">Ordered</a></li>
 <li>List &amp; such</li>
 </ol>"""
 


### PR DESCRIPTION
https://trello.com/c/X4vKC3Bv/112-2-apply-govuk-frontend-styles-to-frameworks-content-for-the-create-a-dos-opportunity-journey

Expands the existing class that adds the `govuk-` classes to paragraphs and lists. We now add classes to update `<a>` and `<h2>` for markdown content in the frameworks repo. 

We're consistently using `govuk-heading-l` for `<h1>` and `govuk-heading-m` for `<h2>` for non-frameworks content across the apps.