### PR TITLE
Add to_summary_list_row method

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.10.0'
+__version__ = '7.11.0'

--- a/dmcontent/html.py
+++ b/dmcontent/html.py
@@ -81,10 +81,56 @@ def to_summary_list_rows(questions, *, filter_empty=True, **kwargs) -> List[dict
     :param bool filter_empty: Whether or not to include unanswered questions in the rows
     """
     return [
-        {"key": {"text": question.label}, "value": {"html": to_html(question, **kwargs)}}
+        to_summary_list_row(question, **kwargs)
         for question in questions
         if not (question.is_empty and filter_empty)
     ]
+
+
+def to_summary_list_row(question, *, action_link=None, **kwargs) -> List[dict]:
+    """Convert a QuestionSummary into a row for govukSummaryList.
+
+    This method expects a QuestionSummary.
+
+    `kwargs` are passed to `to_html`.
+
+    :param string action_link: A link for the row's action
+    """
+    if action_link is not None:
+        empty_message = question.get("empty_message", "Not answered")
+        question_label = question.label + ' (Optional)' if question.is_optional else question.label
+        if question.is_empty:
+            question_value = (
+                Markup(f'<a class="govuk-link" href="{action_link}">{empty_message}</a>')
+            )
+        else:
+            question_value = to_html(question, **kwargs)
+        if not question.is_empty:
+            output = {
+                "key": {"text": question_label},
+                "value": {"html": question_value},
+                "actions": {
+                    "items": [{
+                        "href": action_link,
+                        "text": "Edit",
+                        "visuallyHiddenText": question.label
+                    }]
+                }
+            }
+        else:
+            output = {
+                "key": {"text": question_label},
+                "value": {"html": question_value}
+            }
+    else:
+        question_label = question.label
+        question_value = to_html(question, **kwargs)
+        output = {
+            "key": {"text": question_label},
+            "value": {"html": question_value}
+        }
+
+    return output
 
 
 def text_to_html(

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -726,6 +726,10 @@ class QuestionSummary(Question):
         return ''
 
     @property
+    def is_optional(self):
+        return self.get('optional')
+
+    @property
     def answer_required(self):
         if self.get('optional'):
             return False

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -5,7 +5,7 @@ import pytest
 from jinja2 import Markup
 
 from dmcontent.content_loader import ContentManifest
-from dmcontent.html import text_to_html, to_html, to_summary_list_rows
+from dmcontent.html import text_to_html, to_html, to_summary_list_rows, to_summary_list_row
 
 
 @pytest.fixture
@@ -139,7 +139,13 @@ def content_summary():
                             {"id": "mqUnanswered", "type": "text", "optional": True, "label": "Unanswered question"},
                             {"id": "mqUpload", "type": "upload", "question": "Upload question"}
                         ],
-                    }
+                    },
+                    {
+                        "id": "myUnansweredQuestionWithEmptyMessage",
+                        "type": "text",
+                        "label": "Question which is not answered",
+                        "empty_message": "Enter a text answer"
+                    },
                 ],
             }
         ]
@@ -570,3 +576,34 @@ def test_to_summary_list_rows_can_capitalize_first(content_summary):
             )
         },
     }
+
+
+def test_to_summary_list_row_sets_link_if_question_is_empty_and_action_link_is_set(content_summary):
+    empty_string_question = to_summary_list_row(content_summary.sections[0].questions[6], action_link='/')
+    assert empty_string_question["value"]["html"] == Markup('<a class="govuk-link" href="/">Not answered</a>')
+
+
+def test_to_summary_list_row_sets_value_if_question_has_empty_message_and_action_link_is_set(content_summary):
+    empty_string_question = to_summary_list_row(content_summary.sections[0].questions[25], action_link='/')
+    assert empty_string_question["value"]["html"] == Markup('<a class="govuk-link" href="/">Enter a text answer</a>')
+
+
+def test_to_summary_list_row_sets_no_action_if_question_is_empty_and_action_link_is_set(content_summary):
+    empty_string_question = to_summary_list_row(content_summary.sections[0].questions[6], action_link='/')
+    assert "actions" not in empty_string_question
+
+
+def test_to_summary_list_row_sets_actions_if_question_is_not_empty_and_action_link_is_set(content_summary):
+    empty_string_question = to_summary_list_row(content_summary.sections[0].questions[0], action_link='/')
+    assert empty_string_question["actions"] == {
+        "items": [{
+            "href": '/',
+            "text": "Edit",
+            "visuallyHiddenText": "Boolean question with answer True"
+        }]
+    }
+
+
+def test_to_summary_list_row_adds_optional_label_if_question_is_optional_and_action_link_is_provided(content_summary):
+    empty_string_question = to_summary_list_row(content_summary.sections[0].questions[23], action_link='/')
+    assert empty_string_question["key"]["text"] == "Optional question which is not answered (Optional)"


### PR DESCRIPTION
https://trello.com/c/YF7l0YY3/169-3-replace-summary-tables-in-the-create-dos-opportunity-journey-with-summary-lists

The above ticket requires action links on the summary table which is currently not supported. This PR creates a new method `to_summary_list_row` which defines the logic for introducing these action links.

This is required for https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/336