### PR TITLE
Add dmcontent.govuk_frontend for creating govuk-frontend components from Question objects

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.11.1'
+__version__ = '7.12.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -11,7 +11,18 @@ from dmutils.forms.errors import govuk_error
 from dmcontent.questions import Question
 
 
-__all__ = []
+__all__ = ["govuk_input"]
+
+
+def govuk_input(
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None
+) -> dict:
+    """Create govukInput macro parameters from a text question"""
+
+    params = _params(question, data, errors)
+    params["classes"] = "app-text-input--height-compatible"
+
+    return params
 
 
 def _params(

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -1,0 +1,92 @@
+"""
+Create forms to answer questions using govuk-frontend macros.
+"""
+
+from typing import Optional
+
+from jinja2 import Markup, escape
+
+from dmutils.forms.errors import govuk_error
+
+from dmcontent.questions import Question
+
+
+__all__ = []
+
+
+def _params(
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None
+) -> dict:
+    """Common parameters for govuk-frontent components
+
+    The GOV.UK Design System macro library govuk-frontend has a consistent set
+    of parameters that are used across almost all of its component macros.
+
+    This function abstracts out those common parameters to hopefully simplify
+    creating parameter sets for specific macros.
+
+    *This function should however be considered an implementation detail of
+    this module, and you should avoid using it outside of this file (hence the
+    underscore).*
+
+    The parameters handled by this function include:
+
+        - errorMessage (optional)
+        - hint (optional)
+        - id
+        - label
+        - name
+        - value (optional)
+
+    :returns: A dictionary with parameters that are generally useful for
+              govuk-frontend component macros
+    """
+    params = {
+        "id": f"input-{question.id}",
+        "name": question.id,
+    }
+
+    label_text = question.question
+    if question.is_optional:
+        # GOV.UK Design System says
+        # > mark the labels of optional fields with '(optional)'
+        label_text += " (optional)"
+
+    params["label"] = {
+        # Style the label as a page heading, following the
+        # GOV.UK Design System question pages pattern at
+        # https://design-system.service.gov.uk/patterns/question-pages/
+        "classes": "govuk-label--l",
+        "isPageHeading": True,
+
+        "text": label_text,
+    }
+
+    hint_html = Markup()
+    if question.get("question_advice"):
+        # Put the question advice inside the hint, wrapped in a div
+        # We add the class .app-hint--text so the question advice
+        # can be styled like a normal paragraph with the following Sass
+        #
+        #     .app-hint--text {
+        #       @extend %govuk-body--m
+        #     }
+        hint_html += Markup('<div class="app-hint--text">\n')
+        hint_html += escape(question.question_advice)
+        hint_html += Markup("\n</div>")
+        if question.get("hint"):
+            hint_html += "\n"
+
+    if question.get("hint"):
+        hint_html += escape(question.hint)
+
+    if hint_html:
+        params["hint"] = {"html": hint_html}
+
+    if data and question.id in data:
+        params["value"] = data[question.id]
+
+    if errors and question.id in errors:
+        params["errorMessage"] = govuk_error(errors[question.id])["errorMessage"]
+
+    return params

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -1,5 +1,11 @@
 """
 Create forms to answer questions using govuk-frontend macros.
+
+The main function in this module is `from_question`. It should be possible to
+do everything you might want to do just by calling `from_question` with a
+content loader Question.
+
+Read the docstring for `from_question` for more detail on how this works.
 """
 
 from typing import Optional
@@ -11,7 +17,55 @@ from dmutils.forms.errors import govuk_error
 from dmcontent.questions import Question
 
 
-__all__ = ["govuk_input"]
+__all__ = ["from_question", "govuk_input"]
+
+
+def from_question(
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None
+) -> Optional[dict]:
+    """Create parameters object for govuk-frontend macros from a question
+
+    `from_question` aims to solve the developer need of
+
+        Given a content loader Question
+        I want to create a form element using the GOV.UK Design System
+        So that the user gets a good experience
+
+    in a way that requires the developer to know as little as possible about
+    the Question object in question.
+
+    `from_question` takes a Question and returns a dict containing the name of
+    the govuk-frontend macro to call and the parameters to call it with.
+    Calling the macro with the parameters is left to the app developer.
+
+        >>> from dmcontent import Question
+        >>> from_question(Question({'id': 'q1', 'type': 'text', 'question': ...})
+        {'macro_name': 'govukInput', 'params': {...}}
+
+    A little bit of Jinja magic is required for this;  you need a table of
+    macro names to macros in a Jinja template:
+
+        {% set govuk_forms = {
+            'govukInput': govukInput,
+            'govukRadios': govukRadios,
+            ...
+        } %}
+
+        {% set form = from_question(question) %}
+
+        {{ govuk_forms[question.macro_name](question.params) }}
+
+    :param question: A Question or QuestionSummary
+    :param data: A dict that may contain the answer for question
+    :param errors: A dict which may contain an error message for the question
+
+    :returns: The name of the macro and the parameters in a dict, or None
+              if we don't know how to handle this type of question
+    """
+    if question.type == "text":
+        return {"macro_name": "govukInput", "params": govuk_input(question, data, errors)}
+    else:
+        return None
 
 
 def govuk_input(

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -10,14 +10,12 @@ Read the docstring for `from_question` for more detail on how this works.
 
 from typing import Optional
 
-from jinja2 import Markup, escape
-
 from dmutils.forms.errors import govuk_error
 
 from dmcontent.questions import Question
 
 
-__all__ = ["from_question", "govuk_input"]
+__all__ = ["from_question", "govuk_input", "govuk_label"]
 
 
 def from_question(
@@ -35,12 +33,13 @@ def from_question(
     the Question object in question.
 
     `from_question` takes a Question and returns a dict containing the name of
-    the govuk-frontend macro to call and the parameters to call it with.
-    Calling the macro with the parameters is left to the app developer.
+    the govuk-frontend macro to call and the parameters to call it with, as
+    well as associated components such as labels or fieldsets.  Calling the
+    macro(s) with the parameters is left to the app developer.
 
         >>> from dmcontent import Question
         >>> from_question(Question({'id': 'q1', 'type': 'text', 'question': ...})
-        {'macro_name': 'govukInput', 'params': {...}}
+        {'label': {...}, 'macro_name': 'govukInput', 'params': {...}}
 
     A little bit of Jinja magic is required for this;  you need a table of
     macro names to macros in a Jinja template:
@@ -53,17 +52,24 @@ def from_question(
 
         {% set form = from_question(question) %}
 
-        {{ govuk_forms[question.macro_name](question.params) }}
+        {% if form.label %}
+        {{ govukLabel[form.label] }}
+        {% endif %}
+        {{ govuk_forms[form.macro_name](form.parameters) }}
 
     :param question: A Question or QuestionSummary
     :param data: A dict that may contain the answer for question
     :param errors: A dict which may contain an error message for the question
 
-    :returns: The name of the macro and the parameters in a dict, or None
+    :returns: A dict with the macro name, macro parameters, and labels, or None
               if we don't know how to handle this type of question
     """
     if question.type == "text":
-        return {"macro_name": "govukInput", "params": govuk_input(question, data, errors)}
+        return {
+            "label": govuk_label(question),
+            "macro_name": "govukInput",
+            "params": govuk_input(question, data, errors),
+        }
     else:
         return None
 
@@ -77,6 +83,25 @@ def govuk_input(
     params["classes"] = "app-text-input--height-compatible"
 
     return params
+
+
+def govuk_label(question: Question) -> dict:
+    label_text = question.question
+    if question.is_optional:
+        # GOV.UK Design System says
+        # > mark the labels of optional fields with '(optional)'
+        label_text += " (optional)"
+
+    return {
+        # Style the label as a page heading, following the
+        # GOV.UK Design System question pages pattern at
+        # https://design-system.service.gov.uk/patterns/question-pages/
+        "classes": "govuk-label--l",
+        "isPageHeading": True,
+
+        "for": f"input-{question.id}",
+        "text": label_text,
+    }
 
 
 def _params(
@@ -99,7 +124,6 @@ def _params(
         - errorMessage (optional)
         - hint (optional)
         - id
-        - label
         - name
         - value (optional)
 
@@ -111,42 +135,8 @@ def _params(
         "name": question.id,
     }
 
-    label_text = question.question
-    if question.is_optional:
-        # GOV.UK Design System says
-        # > mark the labels of optional fields with '(optional)'
-        label_text += " (optional)"
-
-    params["label"] = {
-        # Style the label as a page heading, following the
-        # GOV.UK Design System question pages pattern at
-        # https://design-system.service.gov.uk/patterns/question-pages/
-        "classes": "govuk-label--l",
-        "isPageHeading": True,
-
-        "text": label_text,
-    }
-
-    hint_html = Markup()
-    if question.get("question_advice"):
-        # Put the question advice inside the hint, wrapped in a div
-        # We add the class .app-hint--text so the question advice
-        # can be styled like a normal paragraph with the following Sass
-        #
-        #     .app-hint--text {
-        #       @extend %govuk-body--m
-        #     }
-        hint_html += Markup('<div class="app-hint--text">\n')
-        hint_html += escape(question.question_advice)
-        hint_html += Markup("\n</div>")
-        if question.get("hint"):
-            hint_html += "\n"
-
     if question.get("hint"):
-        hint_html += escape(question.hint)
-
-    if hint_html:
-        params["hint"] = {"html": hint_html}
+        params["hint"] = {"text": question.hint}
 
     if data and question.id in data:
         params["value"] = data[question.id]

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -169,6 +169,10 @@ class Question(object):
         return [self.id]
 
     @property
+    def is_optional(self):
+        return self.get('optional')
+
+    @property
     def values_followup(self):
         """Return a reversed (value->followups) followup mapping
 
@@ -725,10 +729,6 @@ class QuestionSummary(Question):
         if self.has_assurance():
             return self._service_data.get(self.id, {}).get('assurance', '')
         return ''
-
-    @property
-    def is_optional(self):
-        return self.get('optional')
 
     @property
     def answer_required(self):

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -8,3 +8,4 @@ flake8<3.8.0,>=3.7.7
 mock
 pytest>=4.6.0
 pytest-cov
+syrupy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,10 +4,11 @@
 #
 #    pip-compile requirements-dev.in
 #
-attrs==19.3.0             # via pytest
+attrs==19.3.0             # via pytest, syrupy
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via pip-tools
+colored==1.4.2            # via syrupy
 coverage==5.2.1           # via -r requirements-dev.in, coveralls, pytest-cov
 coveralls==2.1.1          # via -r requirements-dev.in
 docopt==0.6.2             # via coveralls
@@ -27,10 +28,12 @@ pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements-dev.in
-pytest==6.0.1             # via -r requirements-dev.in, pytest-cov
+pytest==6.0.1             # via -r requirements-dev.in, pytest-cov, syrupy
 requests==2.24.0          # via coveralls
 six==1.15.0               # via packaging, pip-tools
+syrupy==0.6.1             # via -r requirements-dev.in
 toml==0.10.1              # via pytest
+typing-extensions==3.7.4.2  # via syrupy
 urllib3==1.25.10          # via requests
 zipp==3.1.0               # via importlib-metadata
 

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -1,0 +1,64 @@
+# name: TestTextInput.test_govuk_input
+  <class 'dict'> {
+    'classes': 'app-text-input--height-compatible',
+    'hint': <class 'dict'> {
+      'html': '
+        <div class="app-hint--text">
+        This will help you to refer to your requirements
+        </div>
+        100 characters maximum
+      ',
+    },
+    'id': 'input-title',
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'isPageHeading': True,
+      'text': 'What you want to call your requirements',
+    },
+    'name': 'title',
+  }
+---
+# name: TestTextInput.test_with_data
+  <class 'dict'> {
+    'classes': 'app-text-input--height-compatible',
+    'hint': <class 'dict'> {
+      'html': '
+        <div class="app-hint--text">
+        This will help you to refer to your requirements
+        </div>
+        100 characters maximum
+      ',
+    },
+    'id': 'input-title',
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'isPageHeading': True,
+      'text': 'What you want to call your requirements',
+    },
+    'name': 'title',
+    'value': 'Find an individual specialist',
+  }
+---
+# name: TestTextInput.test_with_errors
+  <class 'dict'> {
+    'classes': 'app-text-input--height-compatible',
+    'errorMessage': <class 'dict'> {
+      'text': 'Enter a title.',
+    },
+    'hint': <class 'dict'> {
+      'html': '
+        <div class="app-hint--text">
+        This will help you to refer to your requirements
+        </div>
+        100 characters maximum
+      ',
+    },
+    'id': 'input-title',
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'isPageHeading': True,
+      'text': 'What you want to call your requirements',
+    },
+    'name': 'title',
+  }
+---

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -1,3 +1,23 @@
+# name: TestTextInput.test_from_question
+  <class 'dict'> {
+    'classes': 'app-text-input--height-compatible',
+    'hint': <class 'dict'> {
+      'html': '
+        <div class="app-hint--text">
+        This will help you to refer to your requirements
+        </div>
+        100 characters maximum
+      ',
+    },
+    'id': 'input-title',
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'isPageHeading': True,
+      'text': 'What you want to call your requirements',
+    },
+    'name': 'title',
+  }
+---
 # name: TestTextInput.test_govuk_input
   <class 'dict'> {
     'classes': 'app-text-input--height-compatible',
@@ -20,45 +40,51 @@
 ---
 # name: TestTextInput.test_with_data
   <class 'dict'> {
-    'classes': 'app-text-input--height-compatible',
-    'hint': <class 'dict'> {
-      'html': '
-        <div class="app-hint--text">
-        This will help you to refer to your requirements
-        </div>
-        100 characters maximum
-      ',
+    'macro_name': 'govukInput',
+    'params': <class 'dict'> {
+      'classes': 'app-text-input--height-compatible',
+      'hint': <class 'dict'> {
+        'html': '
+          <div class="app-hint--text">
+          This will help you to refer to your requirements
+          </div>
+          100 characters maximum
+        ',
+      },
+      'id': 'input-title',
+      'label': <class 'dict'> {
+        'classes': 'govuk-label--l',
+        'isPageHeading': True,
+        'text': 'What you want to call your requirements',
+      },
+      'name': 'title',
+      'value': 'Find an individual specialist',
     },
-    'id': 'input-title',
-    'label': <class 'dict'> {
-      'classes': 'govuk-label--l',
-      'isPageHeading': True,
-      'text': 'What you want to call your requirements',
-    },
-    'name': 'title',
-    'value': 'Find an individual specialist',
   }
 ---
 # name: TestTextInput.test_with_errors
   <class 'dict'> {
-    'classes': 'app-text-input--height-compatible',
-    'errorMessage': <class 'dict'> {
-      'text': 'Enter a title.',
+    'macro_name': 'govukInput',
+    'params': <class 'dict'> {
+      'classes': 'app-text-input--height-compatible',
+      'errorMessage': <class 'dict'> {
+        'text': 'Enter a title.',
+      },
+      'hint': <class 'dict'> {
+        'html': '
+          <div class="app-hint--text">
+          This will help you to refer to your requirements
+          </div>
+          100 characters maximum
+        ',
+      },
+      'id': 'input-title',
+      'label': <class 'dict'> {
+        'classes': 'govuk-label--l',
+        'isPageHeading': True,
+        'text': 'What you want to call your requirements',
+      },
+      'name': 'title',
     },
-    'hint': <class 'dict'> {
-      'html': '
-        <div class="app-hint--text">
-        This will help you to refer to your requirements
-        </div>
-        100 characters maximum
-      ',
-    },
-    'id': 'input-title',
-    'label': <class 'dict'> {
-      'classes': 'govuk-label--l',
-      'isPageHeading': True,
-      'text': 'What you want to call your requirements',
-    },
-    'name': 'title',
   }
 ---

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -2,19 +2,9 @@
   <class 'dict'> {
     'classes': 'app-text-input--height-compatible',
     'hint': <class 'dict'> {
-      'html': '
-        <div class="app-hint--text">
-        This will help you to refer to your requirements
-        </div>
-        100 characters maximum
-      ',
+      'text': '100 characters maximum',
     },
     'id': 'input-title',
-    'label': <class 'dict'> {
-      'classes': 'govuk-label--l',
-      'isPageHeading': True,
-      'text': 'What you want to call your requirements',
-    },
     'name': 'title',
   }
 ---
@@ -22,41 +12,27 @@
   <class 'dict'> {
     'classes': 'app-text-input--height-compatible',
     'hint': <class 'dict'> {
-      'html': '
-        <div class="app-hint--text">
-        This will help you to refer to your requirements
-        </div>
-        100 characters maximum
-      ',
+      'text': '100 characters maximum',
     },
     'id': 'input-title',
-    'label': <class 'dict'> {
-      'classes': 'govuk-label--l',
-      'isPageHeading': True,
-      'text': 'What you want to call your requirements',
-    },
     'name': 'title',
   }
 ---
 # name: TestTextInput.test_with_data
   <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-title',
+      'isPageHeading': True,
+      'text': 'What you want to call your requirements',
+    },
     'macro_name': 'govukInput',
     'params': <class 'dict'> {
       'classes': 'app-text-input--height-compatible',
       'hint': <class 'dict'> {
-        'html': '
-          <div class="app-hint--text">
-          This will help you to refer to your requirements
-          </div>
-          100 characters maximum
-        ',
+        'text': '100 characters maximum',
       },
       'id': 'input-title',
-      'label': <class 'dict'> {
-        'classes': 'govuk-label--l',
-        'isPageHeading': True,
-        'text': 'What you want to call your requirements',
-      },
       'name': 'title',
       'value': 'Find an individual specialist',
     },
@@ -64,6 +40,12 @@
 ---
 # name: TestTextInput.test_with_errors
   <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-title',
+      'isPageHeading': True,
+      'text': 'What you want to call your requirements',
+    },
     'macro_name': 'govukInput',
     'params': <class 'dict'> {
       'classes': 'app-text-input--height-compatible',
@@ -71,19 +53,9 @@
         'text': 'Enter a title.',
       },
       'hint': <class 'dict'> {
-        'html': '
-          <div class="app-hint--text">
-          This will help you to refer to your requirements
-          </div>
-          100 characters maximum
-        ',
+        'text': '100 characters maximum',
       },
       'id': 'input-title',
-      'label': <class 'dict'> {
-        'classes': 'govuk-label--l',
-        'isPageHeading': True,
-        'text': 'What you want to call your requirements',
-      },
       'name': 'title',
     },
   }

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -4,7 +4,93 @@ from jinja2 import Markup
 
 from dmcontent.questions import Question
 
-from dmcontent.govuk_frontend import _params
+from dmcontent.govuk_frontend import govuk_input, _params
+
+
+class TestTextInput:
+    @pytest.fixture
+    def question(self):
+        return Question(
+            {
+                "id": "title",
+                "name": "Title",
+                "question": "What you want to call your requirements",
+                "question_advice": "This will help you to refer to your requirements",
+                "hint": "100 characters maximum",
+                "type": "text",
+            }
+        )
+
+    def test_govuk_input(self, question):
+        assert govuk_input(question) == {
+            "classes": "app-text-input--height-compatible",
+            "id": "input-title",
+            "name": "title",
+            "label": {
+                "classes": "govuk-label--l",
+                "isPageHeading": True,
+                "text": "What you want to call your requirements",
+            },
+            "hint": {
+                "html": '<div class="app-hint--text">\n'
+                'This will help you to refer to your requirements\n'
+                '</div>\n'
+                '100 characters maximum'
+            },
+        }
+
+    def test_with_data(self, question):
+        data = {
+            "title": "Find an individual specialist",
+        }
+
+        assert govuk_input(question, data) == {
+            "classes": "app-text-input--height-compatible",
+            "id": "input-title",
+            "name": "title",
+            "label": {
+                "classes": "govuk-label--l",
+                "isPageHeading": True,
+                "text": "What you want to call your requirements",
+            },
+            "hint": {
+                "html": '<div class="app-hint--text">\n'
+                'This will help you to refer to your requirements\n'
+                '</div>\n'
+                '100 characters maximum'
+            },
+            "value": "Find an individual specialist",
+        }
+
+    def test_with_errors(self, question):
+        errors = {
+            "title": {
+                "input_name": "title",
+                "href": "#input-title",
+                "question": "What you want to call your requirements",
+                "message": "Enter a title.",
+            }
+        }
+
+        assert govuk_input(question, errors=errors) == {
+            "classes": "app-text-input--height-compatible",
+            "id": "input-title",
+            "name": "title",
+            "label": {
+                "classes": "govuk-label--l",
+                "isPageHeading": True,
+                "text": "What you want to call your requirements",
+            },
+            "hint": {
+                "html": '<div class="app-hint--text">\n'
+                'This will help you to refer to your requirements\n'
+                '</div>\n'
+                '100 characters maximum'
+            },
+            "errorMessage": {
+                "text": "Enter a title.",
+            },
+        }
 
 
 class TestParams:

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -21,48 +21,17 @@ class TestTextInput:
             }
         )
 
-    def test_govuk_input(self, question):
-        assert govuk_input(question) == {
-            "classes": "app-text-input--height-compatible",
-            "id": "input-title",
-            "name": "title",
-            "label": {
-                "classes": "govuk-label--l",
-                "isPageHeading": True,
-                "text": "What you want to call your requirements",
-            },
-            "hint": {
-                "html": '<div class="app-hint--text">\n'
-                'This will help you to refer to your requirements\n'
-                '</div>\n'
-                '100 characters maximum'
-            },
-        }
+    def test_govuk_input(self, question, snapshot):
+        assert govuk_input(question) == snapshot
 
-    def test_with_data(self, question):
+    def test_with_data(self, question, snapshot):
         data = {
             "title": "Find an individual specialist",
         }
 
-        assert govuk_input(question, data) == {
-            "classes": "app-text-input--height-compatible",
-            "id": "input-title",
-            "name": "title",
-            "label": {
-                "classes": "govuk-label--l",
-                "isPageHeading": True,
-                "text": "What you want to call your requirements",
-            },
-            "hint": {
-                "html": '<div class="app-hint--text">\n'
-                'This will help you to refer to your requirements\n'
-                '</div>\n'
-                '100 characters maximum'
-            },
-            "value": "Find an individual specialist",
-        }
+        assert govuk_input(question, data) == snapshot
 
-    def test_with_errors(self, question):
+    def test_with_errors(self, question, snapshot):
         errors = {
             "title": {
                 "input_name": "title",
@@ -72,25 +41,7 @@ class TestTextInput:
             }
         }
 
-        assert govuk_input(question, errors=errors) == {
-            "classes": "app-text-input--height-compatible",
-            "id": "input-title",
-            "name": "title",
-            "label": {
-                "classes": "govuk-label--l",
-                "isPageHeading": True,
-                "text": "What you want to call your requirements",
-            },
-            "hint": {
-                "html": '<div class="app-hint--text">\n'
-                'This will help you to refer to your requirements\n'
-                '</div>\n'
-                '100 characters maximum'
-            },
-            "errorMessage": {
-                "text": "Enter a title.",
-            },
-        }
+        assert govuk_input(question, errors=errors) == snapshot
 
 
 class TestParams:

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -1,0 +1,129 @@
+import pytest
+
+from jinja2 import Markup
+
+from dmcontent.questions import Question
+
+from dmcontent.govuk_frontend import _params
+
+
+class TestParams:
+    @pytest.fixture
+    def question(self):
+        return Question({"id": "question", "question": "Yes or no?"})
+
+    def test_govuk_input(self, question):
+        assert _params(question) == {
+            "id": "input-question",
+            "name": "question",
+            "label": {
+                "classes": "govuk-label--l",
+                "isPageHeading": True,
+                "text": "Yes or no?",
+            },
+        }
+
+    def test_hint(self, question):
+        question.hint = "Answer yes or no"
+
+        assert _params(question)["hint"] == {
+            "html": "Answer yes or no",
+        }
+
+    def test_hint_is_escaped(self, question):
+        question.hint = "<script>"
+
+        assert _params(question)["hint"]["html"] == "&lt;script&gt;"
+
+    def test_question_advice_is_part_of_hint(self, question):
+        question.question_advice = "You should answer yes or no."
+
+        hint = _params(question)["hint"]
+
+        assert hint == {
+            "html": '<div class="app-hint--text">\n'
+            "You should answer yes or no.\n"
+            "</div>"
+        }
+        assert isinstance(hint["html"], Markup)
+
+    def test_question_advice_is_escaped(self, question):
+        question.question_advice = "<script>"
+
+        assert _params(question)["hint"] == {
+            "html": '<div class="app-hint--text">\n' "&lt;script&gt;\n" "</div>"
+        }
+
+    def test_question_advice_and_hint(self, question):
+        question.hint = "Answer yes or no"
+        question.question_advice = "You should answer yes or no."
+
+        assert _params(question)["hint"] == {
+            "html": '<div class="app-hint--text">\n'
+            "You should answer yes or no.\n"
+            "</div>\n"
+            "Answer yes or no"
+        }
+
+    def test_optional_question_has_optional_in_label_text(self, question):
+        question.optional = True
+
+        assert _params(question)["label"]["text"] == "Yes or no? (optional)"
+
+    def test_not_optional_question_does_not_have_optional_in_label_text(self, question):
+        question.optional = False
+
+        assert _params(question)["label"]["text"] == "Yes or no?"
+
+    def test_value_is_present_if_question_answer_is_in_data(self, question):
+        data = {"question": "Yes"}
+
+        assert _params(question, data)["value"] == "Yes"
+
+    def test_value_is_not_present_if_question_answer_is_not_in_data(self, question):
+        data = {"another_question": "Maybe"}
+
+        assert "value" not in _params(question, data)
+
+    def test_error_message_is_present_if_question_error_is_in_errors(self, question):
+        errors = {
+            "question": {
+                "input_name": "question",
+                "href": "#input-question",
+                "question": "Yes or no?",
+                "message": "Answer yes or no.",
+            }
+        }
+
+        assert _params(question, errors=errors)["errorMessage"] == {
+            "text": "Answer yes or no."
+        }
+
+    def test_error_message_is_not_present_if_question_error_is_not_in_errors(
+        self, question
+    ):
+        errors = {
+            "another_question": {
+                "input_name": "another-question",
+                "href": "#input-another-question",
+                "question": "Are you sure?",
+                "message": "Enter whether you are sure or not.",
+            }
+        }
+
+        assert "errorMessage" not in _params(question, errors=errors)
+
+    def test_value_and_error_message(self, question):
+        data = {"question": "Definitely"}
+        errors = {
+            "question": {
+                "input_name": "question",
+                "href": "#input-question",
+                "question": "Yes or no?",
+                "message": "Answer yes or no only.",
+            }
+        }
+
+        params = _params(question, data, errors)
+        assert params["value"] == "Definitely"
+        assert params["errorMessage"]["text"] == "Answer yes or no only."

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -4,7 +4,7 @@ from jinja2 import Markup
 
 from dmcontent.questions import Question
 
-from dmcontent.govuk_frontend import govuk_input, _params
+from dmcontent.govuk_frontend import from_question, govuk_input, _params
 
 
 class TestTextInput:
@@ -24,12 +24,18 @@ class TestTextInput:
     def test_govuk_input(self, question, snapshot):
         assert govuk_input(question) == snapshot
 
+    def test_from_question(self, question, snapshot):
+        form = from_question(question)
+
+        assert form["macro_name"] == "govukInput"
+        assert form["params"] == snapshot
+
     def test_with_data(self, question, snapshot):
         data = {
             "title": "Find an individual specialist",
         }
 
-        assert govuk_input(question, data) == snapshot
+        assert from_question(question, data) == snapshot
 
     def test_with_errors(self, question, snapshot):
         errors = {
@@ -41,7 +47,7 @@ class TestTextInput:
             }
         }
 
-        assert govuk_input(question, errors=errors) == snapshot
+        assert from_question(question, errors=errors) == snapshot
 
 
 class TestParams:


### PR DESCRIPTION
This is my contribution to https://trello.com/c/YXsBOrDK/110-3-replace-text-boxes-with-govuk-frontend-text-input-component-in-create-a-dos-opportunity-journey. It tries to suggest a way forward for creating govuk-frontend forms from content loader objects.

The basic approach is to move almost all of the logic into Python code. I've put this logic into the content loader repo in this PR, so it can be more easily tested and type-checked (and perhaps one day more easily deleted!). This contrasts to the approach that digitalmarketplace-frontend-toolkit took; all of the formatting and dispatch logic that used to be in the macros `digitalmarketplace-frontend-toolkit/templates/forms` should (in my opinion) live in this module. The benefit of this is easier testing, as well as (in my opinion) increased readability.

The one thing that this code can't and in my opinion shouldn't do is calling the Jinja macros themselves. This does mean we need some extra Jinja magic in our frontend apps; The [briefs frontend PR that goes with this PR](https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/337) I think shows how this could be done.

The main function in this module and in this PR is `dmcontent.govuk_frontend.from_question`. My design intent with this is that it should encapsulate the dispatch logic i.e. it should be the main entry point if you have a Question object and just want to get parameters out. The idea is to make things simpler for developers and have sensible defaults. Let me know if this sounds like a bad idea.

On the subject of sensible defaults, there are quite a few things that could be configurable that aren't right now; I decided to err on the side of "you're not going to need it" and not make the functions very flexible. If that needs to change it should be straightforward however, and I think the benefit of the simpler code is worth it for now.

There's a lot in this PR, so please do read and comment with questions, or leave a thumbs up if it all makes sense to you.

## Other notes

### _params function

As noted in the commit message and docstring, this function is an implementation detail and should not be used outside of this module. It is going have to change in future, especially so we can handle labels and legends/fieldsets differently, but there wasn't a need to put that logic in to fulfil the definition of done of the textbox ticket.

I made the decision to split the parameter logic out now rather than waiting because I wanted to show how we can test the logic at a fine-grained level for the internal function and then do higher-level functional tests for the exported functions that get used.

### Labels as page headings

In this PR we always use labels as page headings in the one question per page pattern. That obviously won't work for all of the pages on the Digital Marketplace, however it works for the pages I cared about for this ticket.

I decided not to add the functionality to configure it to leave open different possible ways to configure (or not) in future. For instance, it might be that we can use some property of the question to decide whether the label should be the page heading or not. When we get to multiquestions and more than one question per page this will be something that will need to be considered further, but I think we should park it for now.

### Question advice

This PR also suggests an approach for how to handle the question advice (see https://trello.com/c/RAQa597F/203-spike-figure-out-what-to-do-about-question-advice for background on this).

~~I found the easiest thing to do was to put the question advice in the hint parameter, wrapped with a `div` so it can be styled differently.~~

After talking about the question advice with @domoscargin, we've agreed on a slightly different design for dmcontent.govuk_frontend that puts more responsibility on the caller to put the form together correctly, but gives a better user experience.

See [discussion below](https://github.com/alphagov/digitalmarketplace-content-loader/pull/90#discussion_r468572289) for more details.

### Snapshot testing

To try and keep the tests of functions in govuk_frontend both comprehensive and readable, I've used snapshot testing with `syrupy` to move the expected values into a separate file.

The benefit of this is that the tests are more readable and easier to update (just run `venv/bin/pytest --update-snapshots`), and if the test fails we get very pretty diffs highlighting the change in question.

The downside is that the expected value is now outside of the test file, which means a bit less transparency.

If people hate this I can remove the commit(s) in question and leave the expected value in the tests.