### PR TITLE
Change Question.question_advice to be always Markdown

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.11.0'
+__version__ = '7.11.1'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -545,6 +545,10 @@ class ContentLoader(object):
             if field in question_data:
                 question_data[field] = TemplateField(question_data[field])
 
+        for field in Question.MARKDOWN_FIELDS:
+            if field in question_data:
+                question_data[field] = TemplateField(question_data[field], markdown=True)
+
         """
         We want to support TemplateFields as keys of list items, for example:
         - {options: [{description: '{{ "jinja" }}'}]} in the lot question

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -13,7 +13,8 @@ from .utils import TemplateField, drop_followups, get_option_value
 
 
 class Question(object):
-    TEMPLATE_FIELDS = ['name', 'question', 'hint', 'question_advice']
+    MARKDOWN_FIELDS = ['question_advice']
+    TEMPLATE_FIELDS = ['name', 'question', 'hint']
     TEMPLATE_OPTIONS_FIELDS = [('options', 'description'), ('validations', 'message')]
 
     def __init__(self, data, number=None, _context=None):

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1889,6 +1889,20 @@ class TestContentLoader(object):
         read_yaml_mock.assert_called_with(
             'content/frameworks/framework-slug/questions/question-set/question1.yml')
 
+    def test_get_question_question_advice_is_always_markdown(self, read_yaml_mock):
+        read_yaml_mock.return_value = {
+            "name": "question1",
+            "question": "Question one",
+            "question_advice": "This is the first question",
+        }
+
+        yaml_loader = ContentLoader('content/')
+        question = yaml_loader.get_question('framework-slug', 'question-set', 'question1')
+        question_advice = question["question_advice"]
+
+        assert question_advice.markdown is True
+        assert question_advice.render() == '<p class="govuk-body">This is the first question</p>'
+
     def test_get_question_uses_id_if_available(self, read_yaml_mock):
         read_yaml_mock.return_value = self.question2()
 


### PR DESCRIPTION
We're having issues where the question advice is sometimes wrapped in HTML `p` tags, and sometimes isn't.

Ideally it would be consistent, so this commit changes the behaviour of the content loader to always treat the `question_advice` field as Markdown.  This means it will always be HTML `<p>`s!