### PR TITLE
Add List Input to dmcontent.govuk_frontend

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.12.0'
+__version__ = '7.13.0'

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -1,3 +1,110 @@
+# name: TestDmListInput.test_dm_list_input
+  <class 'dict'> {
+    'addButtonName': 'item',
+    'fieldset': <class 'dict'> {
+      'legend': <class 'dict'> {
+        'classes': 'govuk-fieldset__legend--l',
+        'isPageHeading': True,
+        'text': 'Cultural fit criteria',
+      },
+    },
+    'hint': <class 'dict'> {
+      'text': 'Enter at least one criteria',
+    },
+    'id': 'input-culturalFitCriteria',
+    'itemLabelPrefix': 'Cultural fit criteria',
+    'items': <class 'list'> [
+    ],
+    'maxItems': 5,
+    'name': 'culturalFitCriteria',
+    'question_advice': '<p class="govuk-body">Cultural fit is about how well you and the specialist work together</p>',
+  }
+---
+# name: TestDmListInput.test_from_question
+  <class 'dict'> {
+    'addButtonName': 'item',
+    'fieldset': <class 'dict'> {
+      'legend': <class 'dict'> {
+        'classes': 'govuk-fieldset__legend--l',
+        'isPageHeading': True,
+        'text': 'Cultural fit criteria',
+      },
+    },
+    'hint': <class 'dict'> {
+      'text': 'Enter at least one criteria',
+    },
+    'id': 'input-culturalFitCriteria',
+    'itemLabelPrefix': 'Cultural fit criteria',
+    'items': <class 'list'> [
+    ],
+    'maxItems': 5,
+    'name': 'culturalFitCriteria',
+    'question_advice': '<p class="govuk-body">Cultural fit is about how well you and the specialist work together</p>',
+  }
+---
+# name: TestDmListInput.test_with_data
+  <class 'dict'> {
+    'macro_name': 'dmListInput',
+    'params': <class 'dict'> {
+      'addButtonName': 'item',
+      'fieldset': <class 'dict'> {
+        'legend': <class 'dict'> {
+          'classes': 'govuk-fieldset__legend--l',
+          'isPageHeading': True,
+          'text': 'Cultural fit criteria',
+        },
+      },
+      'hint': <class 'dict'> {
+        'text': 'Enter at least one criteria',
+      },
+      'id': 'input-culturalFitCriteria',
+      'itemLabelPrefix': 'Cultural fit criteria',
+      'items': <class 'list'> [
+        <class 'dict'> {
+          'value': 'Must know how to make tea',
+        },
+        <class 'dict'> {
+          'value': 'Must believe unicorns',
+        },
+      ],
+      'maxItems': 5,
+      'name': 'culturalFitCriteria',
+      'question_advice': '<p class="govuk-body">Cultural fit is about how well you and the specialist work together</p>',
+      'value': <class 'list'> [
+        'Must know how to make tea',
+        'Must believe unicorns',
+      ],
+    },
+  }
+---
+# name: TestDmListInput.test_with_errors
+  <class 'dict'> {
+    'macro_name': 'dmListInput',
+    'params': <class 'dict'> {
+      'addButtonName': 'item',
+      'errorMessage': <class 'dict'> {
+        'text': 'Enter at least one criterion.',
+      },
+      'fieldset': <class 'dict'> {
+        'legend': <class 'dict'> {
+          'classes': 'govuk-fieldset__legend--l',
+          'isPageHeading': True,
+          'text': 'Cultural fit criteria',
+        },
+      },
+      'hint': <class 'dict'> {
+        'text': 'Enter at least one criteria',
+      },
+      'id': 'input-culturalFitCriteria',
+      'itemLabelPrefix': 'Cultural fit criteria',
+      'items': <class 'list'> [
+      ],
+      'maxItems': 5,
+      'name': 'culturalFitCriteria',
+      'question_advice': '<p class="govuk-body">Cultural fit is about how well you and the specialist work together</p>',
+    },
+  }
+---
 # name: TestTextInput.test_from_question
   <class 'dict'> {
     'classes': 'app-text-input--height-compatible',


### PR DESCRIPTION
https://trello.com/c/VG4caYdJ/136-3-replace-list-form-with-list-input-component-in-create-a-dos-opportunity-journey

For Questions of type "list", we use the new List Input component.

Because this uses a fieldset legend as the question heading, we have less flexibility in where we can place it since it must wrap around its fields. 

Because we can alter List Input to suit our needs, we can simply account for question advice within the component itself. (See https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/163).

GOVUK components like Checkboxes will be trickier to handle, but I've left that as out of scope for this ticket.

This is for use on the Briefs FE: https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/339