### PR TITLE
Add is_page_heading property

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.13.0'
+__version__ = '7.14.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -19,7 +19,7 @@ __all__ = ["from_question", "govuk_input", "govuk_label"]
 
 
 def from_question(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> Optional[dict]:
     """Create parameters object for govuk-frontend macros from a question
 
@@ -66,21 +66,21 @@ def from_question(
     """
     if question.type == "text":
         return {
-            "label": govuk_label(question),
+            "label": govuk_label(question, **kwargs),
             "macro_name": "govukInput",
-            "params": govuk_input(question, data, errors),
+            "params": govuk_input(question, data, errors, **kwargs),
         }
     elif question.type == "list":
         return {
             "macro_name": "dmListInput",
-            "params": dm_list_input(question, data, errors)
+            "params": dm_list_input(question, data, errors, **kwargs)
         }
     else:
         return None
 
 
 def govuk_input(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
     """Create govukInput macro parameters from a text question"""
 
@@ -91,7 +91,7 @@ def govuk_input(
 
 
 def dm_list_input(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
     """Create dmListInput macro parameters from a list question"""
 
@@ -103,7 +103,7 @@ def dm_list_input(
     params["items"] = []
     params["itemLabelPrefix"] = str(question.question)
 
-    params["fieldset"] = govuk_fieldset(question)
+    params["fieldset"] = govuk_fieldset(question, **kwargs)
 
     if question.question_advice:
         params["question_advice"] = question.question_advice
@@ -119,29 +119,38 @@ def dm_list_input(
     return params
 
 
-def govuk_label(question: Question) -> dict:
+def govuk_label(question: Question, *, is_page_heading: bool = True, **kwargs) -> dict:
+    """
+    :param bool is_page_heading: If True, the label will be set to display as a page heading
+    """
 
-    return {
-        # Style the label as a page heading, following the
-        # GOV.UK Design System question pages pattern at
-        # https://design-system.service.gov.uk/patterns/question-pages/
-        "classes": "govuk-label--l",
-        "isPageHeading": True,
-
+    label = {
         "for": f"input-{question.id}",
         "text": get_label_text(question),
     }
+    if is_page_heading:
+        label["classes"] = "govuk-label--l"
+        label["isPageHeading"] = is_page_heading
+
+    return label
 
 
-def govuk_fieldset(question: Question) -> dict:
+def govuk_fieldset(question: Question, *, is_page_heading: bool = True, **kwargs) -> dict:
+    """
+    :param bool is_page_heading: If True, the legend will be set to display as a page heading
+    """
 
-    return {
+    fieldset = {
         "legend": {
             "text": get_label_text(question),
-            "isPageHeading": True,
-            "classes": "govuk-fieldset__legend--l"
         }
     }
+
+    if is_page_heading:
+        fieldset["legend"]["isPageHeading"] = is_page_heading
+        fieldset["legend"]["classes"] = "govuk-fieldset__legend--l"
+
+    return fieldset
 
 
 def get_label_text(question: Question) -> str:

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -42,6 +42,26 @@
     'question_advice': '<p class="govuk-body">Cultural fit is about how well you and the specialist work together</p>',
   }
 ---
+# name: TestDmListInput.test_from_question_with_is_page_heading_false
+  <class 'dict'> {
+    'addButtonName': 'item',
+    'fieldset': <class 'dict'> {
+      'legend': <class 'dict'> {
+        'text': 'Cultural fit criteria',
+      },
+    },
+    'hint': <class 'dict'> {
+      'text': 'Enter at least one criteria',
+    },
+    'id': 'input-culturalFitCriteria',
+    'itemLabelPrefix': 'Cultural fit criteria',
+    'items': <class 'list'> [
+    ],
+    'maxItems': 5,
+    'name': 'culturalFitCriteria',
+    'question_advice': '<p class="govuk-body">Cultural fit is about how well you and the specialist work together</p>',
+  }
+---
 # name: TestDmListInput.test_with_data
   <class 'dict'> {
     'macro_name': 'dmListInput',
@@ -106,6 +126,16 @@
   }
 ---
 # name: TestTextInput.test_from_question
+  <class 'dict'> {
+    'classes': 'app-text-input--height-compatible',
+    'hint': <class 'dict'> {
+      'text': '100 characters maximum',
+    },
+    'id': 'input-title',
+    'name': 'title',
+  }
+---
+# name: TestTextInput.test_from_question_with_is_page_heading_false
   <class 'dict'> {
     'classes': 'app-text-input--height-compatible',
     'hint': <class 'dict'> {

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -30,6 +30,12 @@ class TestTextInput:
         assert form["macro_name"] == "govukInput"
         assert form["params"] == snapshot
 
+    def test_from_question_with_is_page_heading_false(self, question, snapshot):
+        form = from_question(question, is_page_heading=False)
+
+        assert form["macro_name"] == "govukInput"
+        assert form["params"] == snapshot
+
     def test_with_data(self, question, snapshot):
         data = {
             "title": "Find an individual specialist",
@@ -76,6 +82,12 @@ class TestDmListInput:
         assert form["macro_name"] == "dmListInput"
         assert form["params"] == snapshot
 
+    def test_from_question_with_is_page_heading_false(self, question, snapshot):
+        form = from_question(question, is_page_heading=False)
+
+        assert form["macro_name"] == "dmListInput"
+        assert form["params"] == snapshot
+
     def test_with_data(self, question, snapshot):
         data = {
             "culturalFitCriteria": ["Must know how to make tea", "Must believe unicorns"],
@@ -109,6 +121,12 @@ class TestGovukLabel:
             "text": "Yes or no?",
         }
 
+    def test_is_page_heading_false_removes_classes_and_ispageheading(self, question):
+        assert govuk_label(question, is_page_heading=False) == {
+            "for": "input-question",
+            "text": "Yes or no?",
+        }
+
     def test_optional_question_has_optional_in_label_text(self, question):
         question.optional = True
 
@@ -131,6 +149,13 @@ class TestGovukFieldset:
                 "text": "Enter your criteria",
                 "isPageHeading": True,
                 "classes": "govuk-fieldset__legend--l"
+            }
+        }
+
+    def test_is_page_heading_false_removes_classes_and_ispageheading(self, question):
+        assert govuk_fieldset(question, is_page_heading=False) == {
+            "legend": {
+                "text": "Enter your criteria"
             }
         }
 


### PR DESCRIPTION
For multiquestions, we don't want each child's label/legend to be set as the page heading, so we need a way to flag this.

This enables the is_page_heading property to be set as appropriate.