### PR TITLE
Fix checks for question.id

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.14.0'
+__version__ = '7.14.1'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -197,10 +197,10 @@ def _params(
     if question.get("hint"):
         params["hint"] = {"text": question.hint}
 
-    if data and question.id in data:
+    if data and data.get(question.id):
         params["value"] = data[question.id]
 
-    if errors and question.id in errors:
+    if errors and errors.get(question.id):
         params["errorMessage"] = govuk_error(errors[question.id])["errorMessage"]
 
     return params

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -200,6 +200,11 @@ class TestParams:
 
         assert "value" not in _params(question, data)
 
+    def test_value_is_not_present_if_question_answer_is_none(self, question):
+        data = {"another_question": None}
+
+        assert "value" not in _params(question, data)
+
     def test_error_message_is_present_if_question_error_is_in_errors(self, question):
         errors = {
             "question": {
@@ -225,6 +230,11 @@ class TestParams:
                 "message": "Enter whether you are sure or not.",
             }
         }
+
+        assert "errorMessage" not in _params(question, errors=errors)
+
+    def test_error_message_is_not_present_if_question_error_is_none(self, question):
+        errors = {"another_question": None}
 
         assert "errorMessage" not in _params(question, errors=errors)
 


### PR DESCRIPTION
Previous checks could result in params["value"] being set to "None", which would display on elements such as textarea.

This change means the value param doesn't even get created in this case.