### PR TITLE
Add character count to dmcontent.govuk_frontend to create params from Question objects

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.15.0'
+__version__ = '7.16.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -82,6 +82,12 @@ def from_question(
             "macro_name": "govukRadios",
             "params": govuk_radios(question, data, errors, **kwargs)
         }
+    elif question.type == "textbox_large":
+        return {
+            "label": govuk_label(question, **kwargs),
+            "macro_name": "govukCharacterCount",
+            "params": govuk_character_count(question, data, errors, **kwargs)
+        }
     else:
         return None
 
@@ -178,6 +184,17 @@ def govuk_fieldset(question: Question, *, is_page_heading: bool = True, **kwargs
         fieldset["legend"]["classes"] = "govuk-fieldset__legend--l"
 
     return fieldset
+
+
+def govuk_character_count(
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+) -> dict:
+    params = _params(question, data, errors)
+
+    if question.get("max_length_in_words"):
+        params["maxwords"] = question.max_length_in_words
+
+    return params
 
 
 def get_label_text(question: Question) -> str:

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -125,6 +125,68 @@
     },
   }
 ---
+# name: TestGovukCharacterCount.test_from_question
+  <class 'dict'> {
+    'hint': <class 'dict'> {
+      'text': 'Enter at least one word, and no more than 100',
+    },
+    'id': 'input-description',
+    'maxwords': 100,
+    'name': 'description',
+  }
+---
+# name: TestGovukCharacterCount.test_govuk_character_count
+  <class 'dict'> {
+    'hint': <class 'dict'> {
+      'text': 'Enter at least one word, and no more than 100',
+    },
+    'id': 'input-description',
+    'maxwords': 100,
+    'name': 'description',
+  }
+---
+# name: TestGovukCharacterCount.test_with_data
+  <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-description',
+      'isPageHeading': True,
+      'text': "Describe the specialist's role",
+    },
+    'macro_name': 'govukCharacterCount',
+    'params': <class 'dict'> {
+      'hint': <class 'dict'> {
+        'text': 'Enter at least one word, and no more than 100',
+      },
+      'id': 'input-description',
+      'maxwords': 100,
+      'name': 'description',
+      'value': 'The specialist must know how to make tea and work well with unicorns.',
+    },
+  }
+---
+# name: TestGovukCharacterCount.test_with_errors
+  <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-description',
+      'isPageHeading': True,
+      'text': "Describe the specialist's role",
+    },
+    'macro_name': 'govukCharacterCount',
+    'params': <class 'dict'> {
+      'errorMessage': <class 'dict'> {
+        'text': "Enter a description of the specialist's role.",
+      },
+      'hint': <class 'dict'> {
+        'text': 'Enter at least one word, and no more than 100',
+      },
+      'id': 'input-description',
+      'maxwords': 100,
+      'name': 'description',
+    },
+  }
+---
 # name: TestRadios.test_from_question
   <class 'dict'> {
     'idPrefix': 'input-yesOrNo',

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -4,6 +4,7 @@ from dmcontent.questions import Question
 
 from dmcontent.govuk_frontend import (
     from_question,
+    govuk_character_count,
     govuk_input,
     govuk_radios,
     dm_list_input,
@@ -183,6 +184,65 @@ class TestDmListInput:
                 "href": "#input-culturalFitCriteria",
                 "question": "Cultural fit criteria",
                 "message": "Enter at least one criterion.",
+            }
+        }
+
+        assert from_question(question, errors=errors) == snapshot
+
+
+class TestGovukCharacterCount:
+    @pytest.fixture
+    def question(self):
+        return Question(
+            {
+                "id": "description",
+                "name": "Description",
+                "question": "Describe the specialist's role",
+                "question_advice": "Describe the team the specialist will be working with on this project.",
+                "type": "textbox_large",
+                "hint": "Enter at least one word, and no more than 100",
+                "max_length_in_words": 100
+            }
+        )
+
+    @pytest.fixture
+    def question_without_word_count(self):
+        return Question(
+            {
+                "id": "description",
+                "name": "Description",
+                "question": "Describe the specialist's role",
+                "question_advice": "Describe the team the specialist will be working with on this project.",
+                "type": "textbox_large"
+            }
+        )
+
+    def test_govuk_character_count(self, question, snapshot):
+        assert govuk_character_count(question) == snapshot
+
+    def test_from_question(self, question, snapshot):
+        form = from_question(question)
+
+        assert form["macro_name"] == "govukCharacterCount"
+        assert form["params"] == snapshot
+
+    def test_question_with_no_max_word_length_does_not_have_maxwords_in_params(self, question_without_word_count):
+        assert "maxwords" not in govuk_character_count(question_without_word_count)
+
+    def test_with_data(self, question, snapshot):
+        data = {
+            "description": "The specialist must know how to make tea and work well with unicorns.",
+        }
+
+        assert from_question(question, data) == snapshot
+
+    def test_with_errors(self, question, snapshot):
+        errors = {
+            "description": {
+                "input_name": "description",
+                "href": "#input-description",
+                "question": "Description",
+                "message": "Enter a description of the specialist's role.",
             }
         }
 


### PR DESCRIPTION
https://trello.com/c/xHVb6nOe/117-2-replace-textarea-component-in-create-a-dos-opportunity-journey

This implements govuk_character_count to generate params for a [govukCharacterCount](https://design-system.service.gov.uk/components/character-count/).

Since we only use maximum word count on the DOS Opportunity journey, this ticket is scoped to that - maximum character count is left as out of scope.