### PR TITLE
Add support for radios questions to dmcontent.govuk_frontend

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.14.1'
+__version__ = '7.15.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -11,6 +11,7 @@ Read the docstring for `from_question` for more detail on how this works.
 from typing import Optional
 
 from dmutils.forms.errors import govuk_error
+from dmutils.forms.helpers import govuk_options
 
 from dmcontent.questions import Question
 
@@ -75,6 +76,12 @@ def from_question(
             "macro_name": "dmListInput",
             "params": dm_list_input(question, data, errors, **kwargs)
         }
+    elif question.type == "radios":
+        return {
+            "fieldset": govuk_fieldset(question, **kwargs),
+            "macro_name": "govukRadios",
+            "params": govuk_radios(question, data, errors, **kwargs)
+        }
     else:
         return None
 
@@ -86,6 +93,26 @@ def govuk_input(
 
     params = _params(question, data, errors)
     params["classes"] = "app-text-input--height-compatible"
+
+    return params
+
+
+def govuk_radios(
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+) -> dict:
+    """Create govukRadios macro parameters from a radios question"""
+
+    if data is None:
+        data = {}
+
+    # we don't pass data to _params because govukRadios deals with value differently
+    params = _params(question, errors=errors)
+
+    # govukRadios wants idPrefix, not id
+    del params["id"]
+    params["idPrefix"] = f"input-{question.id}"
+
+    params["items"] = govuk_options(question.options, data.get(question.id))
 
     return params
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -e .
 # DON'T FORGET TO UPDATE setup.py !!
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.6.0#egg=digitalmarketplace-utils==52.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.9.0#egg=digitalmarketplace-utils==52.9.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'Markdown<3.0.0,>=2.6.7',
         'PyYAML<6.0,>=5.1.2',
         'inflection<1.0.0,>=0.3.1',
-        'digitalmarketplace-utils>=52.6.0',
+        'digitalmarketplace-utils>=52.9.0',
     ],
     python_requires="~=3.6",
 )

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -125,6 +125,103 @@
     },
   }
 ---
+# name: TestRadios.test_from_question
+  <class 'dict'> {
+    'idPrefix': 'input-yesOrNo',
+    'items': <class 'list'> [
+      <class 'dict'> {
+        'text': 'Yes',
+        'value': 'yes',
+      },
+      <class 'dict'> {
+        'text': 'No',
+        'value': 'no',
+      },
+    ],
+    'name': 'yesOrNo',
+  }
+---
+# name: TestRadios.test_from_question_with_data
+  <class 'dict'> {
+    'fieldset': <class 'dict'> {
+      'legend': <class 'dict'> {
+        'classes': 'govuk-fieldset__legend--l',
+        'isPageHeading': True,
+        'text': 'Yes or no?',
+      },
+    },
+    'macro_name': 'govukRadios',
+    'params': <class 'dict'> {
+      'idPrefix': 'input-yesOrNo',
+      'items': <class 'list'> [
+        <class 'dict'> {
+          'checked': True,
+          'text': 'Yes',
+          'value': 'yes',
+        },
+        <class 'dict'> {
+          'text': 'No',
+          'value': 'no',
+        },
+      ],
+      'name': 'yesOrNo',
+    },
+  }
+---
+# name: TestRadios.test_from_question_with_errors
+  <class 'dict'> {
+    'fieldset': <class 'dict'> {
+      'legend': <class 'dict'> {
+        'classes': 'govuk-fieldset__legend--l',
+        'isPageHeading': True,
+        'text': 'Yes or no?',
+      },
+    },
+    'macro_name': 'govukRadios',
+    'params': <class 'dict'> {
+      'errorMessage': <class 'dict'> {
+        'text': 'Select yes or no,',
+      },
+      'idPrefix': 'input-yesOrNo',
+      'items': <class 'list'> [
+        <class 'dict'> {
+          'text': 'Yes',
+          'value': 'yes',
+        },
+        <class 'dict'> {
+          'text': 'No',
+          'value': 'no',
+        },
+      ],
+      'name': 'yesOrNo',
+    },
+  }
+---
+# name: TestRadios.test_from_question_with_is_page_heading_false
+  <class 'dict'> {
+    'legend': <class 'dict'> {
+      'classes': 'govuk-fieldset__legend--l',
+      'isPageHeading': True,
+      'text': 'Yes or no?',
+    },
+  }
+---
+# name: TestRadios.test_govuk_radios
+  <class 'dict'> {
+    'idPrefix': 'input-yesOrNo',
+    'items': <class 'list'> [
+      <class 'dict'> {
+        'text': 'Yes',
+        'value': 'yes',
+      },
+      <class 'dict'> {
+        'text': 'No',
+        'value': 'no',
+      },
+    ],
+    'name': 'yesOrNo',
+  }
+---
 # name: TestTextInput.test_from_question
   <class 'dict'> {
     'classes': 'app-text-input--height-compatible',


### PR DESCRIPTION
Ticket: https://trello.com/c/6xOXfwx7/123-2-use-radios-component-for-radios-questions-in-create-a-dos-opportunity-journey

This adds `govuk_radios` to create params for govukRadio from Question objects, and updates `from_question` to handle that question type.

This uses the [function `govuk_options` from dmutils](https://github.com/alphagov/digitalmarketplace-utils/blob/79cbc5eac674cb438fc90c598b76395f50491a25/dmutils/forms/helpers.py#L70) to do most of the work (thanks @agalamatis!).

It doesn't support questions with type boolean or items with conditionally revealing content, but as we don't use those in the create a DOS opportunity journey I considered that out of scope.