### PR TITLE
Add support for checkboxes questions to dmcontent.govuk_frontend

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.16.0'
+__version__ = '7.17.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -82,6 +82,12 @@ def from_question(
             "macro_name": "govukRadios",
             "params": govuk_radios(question, data, errors, **kwargs)
         }
+    elif question.type == "checkboxes":
+        return {
+            "fieldset": govuk_fieldset(question, **kwargs),
+            "macro_name": "govukCheckboxes",
+            "params": govuk_checkboxes(question, data, errors, **kwargs)
+        }
     elif question.type == "textbox_large":
         return {
             "label": govuk_label(question, **kwargs),
@@ -101,6 +107,14 @@ def govuk_input(
     params["classes"] = "app-text-input--height-compatible"
 
     return params
+
+
+def govuk_checkboxes(
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+) -> dict:
+    """Create govukCheckboxes macro parameters from a checkboxes question"""
+
+    return govuk_radios(question, data, errors, **kwargs)
 
 
 def govuk_radios(

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -1,3 +1,101 @@
+# name: TestCheckboxes.test_from_question
+  <class 'dict'> {
+    'idPrefix': 'input-oneAndAnother',
+    'items': <class 'list'> [
+      <class 'dict'> {
+        'text': 'One',
+        'value': 'one',
+      },
+      <class 'dict'> {
+        'text': 'Another',
+        'value': 'another',
+      },
+    ],
+    'name': 'oneAndAnother',
+  }
+---
+# name: TestCheckboxes.test_from_question_with_data
+  <class 'dict'> {
+    'fieldset': <class 'dict'> {
+      'legend': <class 'dict'> {
+        'classes': 'govuk-fieldset__legend--l',
+        'isPageHeading': True,
+        'text': 'Choose one and/or another',
+      },
+    },
+    'macro_name': 'govukCheckboxes',
+    'params': <class 'dict'> {
+      'idPrefix': 'input-oneAndAnother',
+      'items': <class 'list'> [
+        <class 'dict'> {
+          'checked': True,
+          'text': 'One',
+          'value': 'one',
+        },
+        <class 'dict'> {
+          'checked': True,
+          'text': 'Another',
+          'value': 'another',
+        },
+      ],
+      'name': 'oneAndAnother',
+    },
+  }
+---
+# name: TestCheckboxes.test_from_question_with_errors
+  <class 'dict'> {
+    'fieldset': <class 'dict'> {
+      'legend': <class 'dict'> {
+        'classes': 'govuk-fieldset__legend--l',
+        'isPageHeading': True,
+        'text': 'Choose one and/or another',
+      },
+    },
+    'macro_name': 'govukCheckboxes',
+    'params': <class 'dict'> {
+      'errorMessage': <class 'dict'> {
+        'text': 'Select one or another',
+      },
+      'idPrefix': 'input-oneAndAnother',
+      'items': <class 'list'> [
+        <class 'dict'> {
+          'text': 'One',
+          'value': 'one',
+        },
+        <class 'dict'> {
+          'text': 'Another',
+          'value': 'another',
+        },
+      ],
+      'name': 'oneAndAnother',
+    },
+  }
+---
+# name: TestCheckboxes.test_from_question_with_is_page_heading_false
+  <class 'dict'> {
+    'legend': <class 'dict'> {
+      'classes': 'govuk-fieldset__legend--l',
+      'isPageHeading': True,
+      'text': 'Choose one and/or another',
+    },
+  }
+---
+# name: TestCheckboxes.test_govuk_checkboxes
+  <class 'dict'> {
+    'idPrefix': 'input-oneAndAnother',
+    'items': <class 'list'> [
+      <class 'dict'> {
+        'text': 'One',
+        'value': 'one',
+      },
+      <class 'dict'> {
+        'text': 'Another',
+        'value': 'another',
+      },
+    ],
+    'name': 'oneAndAnother',
+  }
+---
 # name: TestDmListInput.test_dm_list_input
   <class 'dict'> {
     'addButtonName': 'item',


### PR DESCRIPTION
https://trello.com/c/zx1hJsgX/114-2-replace-checkboxes-in-create-a-dos-opportunity-journey

Builds on the work done in #97, adding `govuk_checkboxes` to create params for govukCheckboxes from Question objects, and updates `from_question` to handle that question type.