### PR TITLE
Add support for date questions to dmcontent.govuk_frontend

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.17.0'
+__version__ = '7.18.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -71,6 +71,12 @@ def from_question(
             "macro_name": "govukInput",
             "params": govuk_input(question, data, errors, **kwargs),
         }
+    if question.type == "date":
+        return {
+            "fieldset": govuk_fieldset(question, **kwargs),
+            "macro_name": "govukDateInput",
+            "params": govuk_date_input(question, data, errors, **kwargs),
+        }
     elif question.type == "list":
         return {
             "macro_name": "dmListInput",
@@ -115,6 +121,41 @@ def govuk_checkboxes(
     """Create govukCheckboxes macro parameters from a checkboxes question"""
 
     return govuk_radios(question, data, errors, **kwargs)
+
+
+def govuk_date_input(
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+) -> dict:
+    """Create govukDateInput macro parameters from a date question"""
+
+    params = _params(question, data, errors)
+
+    params["namePrefix"] = question.id
+
+    params["items"] = [
+        {
+            "name": "day",
+            "classes": "govuk-input--width-2"
+        },
+        {
+            "name": "month",
+            "classes": "govuk-input--width-2"
+        },
+        {
+            "name": "year",
+            "classes": "govuk-input--width-4"
+        }
+    ]
+
+    for item in params["items"]:
+        if data:
+            answer_key = f"{question.id}-{item['name']}"
+            if data.get(answer_key):
+                item["value"] = data[answer_key]
+        if errors and errors.get(question.id):
+            item["classes"] += ' govuk-input--error'
+
+    return params
 
 
 def govuk_radios(

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -96,6 +96,125 @@
     'name': 'oneAndAnother',
   }
 ---
+# name: TestDateInput.test_from_question
+  <class 'dict'> {
+    'id': 'input-startDate',
+    'items': <class 'list'> [
+      <class 'dict'> {
+        'classes': 'govuk-input--width-2',
+        'name': 'day',
+      },
+      <class 'dict'> {
+        'classes': 'govuk-input--width-2',
+        'name': 'month',
+      },
+      <class 'dict'> {
+        'classes': 'govuk-input--width-4',
+        'name': 'year',
+      },
+    ],
+    'name': 'startDate',
+    'namePrefix': 'startDate',
+  }
+---
+# name: TestDateInput.test_from_question_with_data
+  <class 'dict'> {
+    'fieldset': <class 'dict'> {
+      'legend': <class 'dict'> {
+        'classes': 'govuk-fieldset__legend--l',
+        'isPageHeading': True,
+        'text': 'What is the latest start date?',
+      },
+    },
+    'macro_name': 'govukDateInput',
+    'params': <class 'dict'> {
+      'id': 'input-startDate',
+      'items': <class 'list'> [
+        <class 'dict'> {
+          'classes': 'govuk-input--width-2',
+          'name': 'day',
+          'value': 1,
+        },
+        <class 'dict'> {
+          'classes': 'govuk-input--width-2',
+          'name': 'month',
+          'value': 12,
+        },
+        <class 'dict'> {
+          'classes': 'govuk-input--width-4',
+          'name': 'year',
+          'value': 2020,
+        },
+      ],
+      'name': 'startDate',
+      'namePrefix': 'startDate',
+    },
+  }
+---
+# name: TestDateInput.test_from_question_with_errors
+  <class 'dict'> {
+    'fieldset': <class 'dict'> {
+      'legend': <class 'dict'> {
+        'classes': 'govuk-fieldset__legend--l',
+        'isPageHeading': True,
+        'text': 'What is the latest start date?',
+      },
+    },
+    'macro_name': 'govukDateInput',
+    'params': <class 'dict'> {
+      'errorMessage': <class 'dict'> {
+        'text': 'Enter a start date',
+      },
+      'id': 'input-startDate',
+      'items': <class 'list'> [
+        <class 'dict'> {
+          'classes': 'govuk-input--width-2 govuk-input--error',
+          'name': 'day',
+        },
+        <class 'dict'> {
+          'classes': 'govuk-input--width-2 govuk-input--error',
+          'name': 'month',
+        },
+        <class 'dict'> {
+          'classes': 'govuk-input--width-4 govuk-input--error',
+          'name': 'year',
+        },
+      ],
+      'name': 'startDate',
+      'namePrefix': 'startDate',
+    },
+  }
+---
+# name: TestDateInput.test_from_question_with_is_page_heading_false
+  <class 'dict'> {
+    'legend': <class 'dict'> {
+      'classes': 'govuk-fieldset__legend--l',
+      'isPageHeading': True,
+      'text': 'What is the latest start date?',
+    },
+  }
+---
+# name: TestDateInput.test_govuk_date_input
+  <class 'dict'> {
+    'id': 'input-startDate',
+    'items': <class 'list'> [
+      <class 'dict'> {
+        'classes': 'govuk-input--width-2',
+        'name': 'day',
+      },
+      <class 'dict'> {
+        'classes': 'govuk-input--width-2',
+        'name': 'month',
+      },
+      <class 'dict'> {
+        'classes': 'govuk-input--width-4',
+        'name': 'year',
+      },
+    ],
+    'name': 'startDate',
+    'namePrefix': 'startDate',
+  }
+---
 # name: TestDmListInput.test_dm_list_input
   <class 'dict'> {
     'addButtonName': 'item',

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -5,6 +5,7 @@ from dmcontent.questions import Question
 from dmcontent.govuk_frontend import (
     from_question,
     govuk_character_count,
+    govuk_date_input,
     govuk_input,
     govuk_checkboxes,
     govuk_radios,
@@ -209,6 +210,66 @@ class TestCheckboxes:
                 "href": "#input-oneAndAnother",
                 "question": "Select one and/or another.",
                 "message": "Select one or another",
+            }
+        }
+
+        form = from_question(question, errors=errors)
+
+        assert "errorMessage" in form["params"]
+        assert form == snapshot
+
+
+class TestDateInput:
+    @pytest.fixture
+    def question(self):
+        return Question(
+            {
+                "id": "startDate",
+                "name": "Latest start date",
+                "question": "What is the latest start date?",
+                "type": "date"
+            }
+        )
+
+    def test_govuk_date_input(self, question, snapshot):
+        assert govuk_date_input(question) == snapshot
+
+    def test_govuk_date_input_name_prefix(self, question):
+        params = govuk_date_input(question)
+
+        assert params["namePrefix"] == question.id
+
+    def test_from_question(self, question, snapshot):
+        form = from_question(question)
+
+        assert "fieldset" in form
+        assert form["macro_name"] == "govukDateInput"
+        assert form["params"] == snapshot
+
+    def test_from_question_with_is_page_heading_false(self, question, snapshot):
+        fieldset = from_question(question)["fieldset"]
+
+        assert "isPageHeading" not in fieldset or fieldset["isPageHeading"] is False
+        assert fieldset == snapshot
+
+    def test_from_question_with_data(self, question, snapshot):
+        data = {"startDate-day": 1, "startDate-month": 12, "startDate-year": 2020}
+
+        form = from_question(question, data)
+
+        assert "value" not in form["params"]
+        assert form["params"]["items"][0]["value"] == 1
+        assert form["params"]["items"][1]["value"] == 12
+        assert form["params"]["items"][2]["value"] == 2020
+        assert form == snapshot
+
+    def test_from_question_with_errors(self, question, snapshot):
+        errors = {
+            "startDate": {
+                "input_name": "startDate",
+                "href": "#input-startDate-day",
+                "question": "What is the latest start date?",
+                "message": "Enter a start date",
             }
         }
 


### PR DESCRIPTION
https://trello.com/c/k2SADNQr/172-2-replace-date-input-component-in-create-a-dos-opportunity-journey

Adds govuk_date_input to create params for govukDateInput from Question objects, and updates from_question to handle that question type.

## Notes
We don't currently do granular error checking for date inputs, and this component reflects that. The [Design System component](https://design-system.service.gov.uk/components/date-input/) does recommend error messages are specific, but I think that's out of scope for this ticket.

Bumped version to 7.18 because the checkboxes PR (#98) is ready to go and I'll merge that first as 7.17.