### PR TITLE
Add fieldset heading class for fieldset legends in multiquestions

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.18.0'
+__version__ = '7.18.1'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -230,6 +230,7 @@ def govuk_fieldset(question: Question, *, is_page_heading: bool = True, **kwargs
 
     fieldset = {
         "legend": {
+            "classes": "govuk-fieldset__legend--m",
             "text": get_label_text(question),
         }
     }

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -264,6 +264,7 @@
     'addButtonName': 'item',
     'fieldset': <class 'dict'> {
       'legend': <class 'dict'> {
+        'classes': 'govuk-fieldset__legend--m',
         'text': 'Cultural fit criteria',
       },
     },

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -437,6 +437,7 @@ class TestGovukFieldset:
     def test_is_page_heading_false_removes_classes_and_ispageheading(self, question):
         assert govuk_fieldset(question, is_page_heading=False) == {
             "legend": {
+                "classes": "govuk-fieldset__legend--m",
                 "text": "Enter your criteria"
             }
         }


### PR DESCRIPTION
If a question legend is not the page heading, we were defaulting to no sizing class on the fieldset legend. This ensures we apply a default legend style.