### PR TITLE
Add support for number questions to govuk_frontend.from_question

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.18.1'
+__version__ = '7.19.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -65,7 +65,7 @@ def from_question(
     :returns: A dict with the macro name, macro parameters, and labels, or None
               if we don't know how to handle this type of question
     """
-    if question.type == "text":
+    if question.type == "text" or question.type == "number":
         return {
             "label": govuk_label(question, **kwargs),
             "macro_name": "govukInput",
@@ -107,10 +107,27 @@ def from_question(
 def govuk_input(
     question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
-    """Create govukInput macro parameters from a text question"""
+    """Create govukInput macro parameters from a text or number question"""
 
     params = _params(question, data, errors)
     params["classes"] = "app-text-input--height-compatible"
+
+    if question.type == "number":
+        params["classes"] += " govuk-input--width-5"
+        params["spellcheck"] = False
+        if question.get("limits") and question.limits.get("integer_only") is True:
+            params["inputmode"] = "numeric"
+            params["pattern"] = "[0-9]*"
+
+        if question.get("unit"):
+            prefix_or_suffix = {"before": "prefix", "after": "suffix"}[question.unit_position]
+            params[prefix_or_suffix] = {"text": question.unit}
+            if params.get("pattern"):
+                unit_regex = f"{question.unit}?"
+                if prefix_or_suffix == "prefix":
+                    params["pattern"] = unit_regex + params["pattern"]
+                elif prefix_or_suffix == "suffix":
+                    params["pattern"] += unit_regex
 
     return params
 

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -264,6 +264,8 @@ def govuk_character_count(
 ) -> dict:
     params = _params(question, data, errors)
 
+    params["spellcheck"] = True
+
     if question.get("max_length_in_words"):
         params["maxwords"] = question.max_length_in_words
 

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -405,6 +405,60 @@
     },
   }
 ---
+# name: TestNumberInput.test_from_question
+  <class 'dict'> {
+    'classes': 'app-text-input--height-compatible govuk-input--width-5',
+    'id': 'input-howMany',
+    'name': 'howMany',
+    'spellcheck': False,
+  }
+---
+# name: TestNumberInput.test_from_question_with_data
+  <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-howMany',
+      'isPageHeading': True,
+      'text': 'How many?',
+    },
+    'macro_name': 'govukInput',
+    'params': <class 'dict'> {
+      'classes': 'app-text-input--height-compatible govuk-input--width-5',
+      'id': 'input-howMany',
+      'name': 'howMany',
+      'spellcheck': False,
+      'value': '10',
+    },
+  }
+---
+# name: TestNumberInput.test_from_question_with_errors
+  <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-howMany',
+      'isPageHeading': True,
+      'text': 'How many?',
+    },
+    'macro_name': 'govukInput',
+    'params': <class 'dict'> {
+      'classes': 'app-text-input--height-compatible govuk-input--width-5',
+      'errorMessage': <class 'dict'> {
+        'text': 'Enter how many',
+      },
+      'id': 'input-howMany',
+      'name': 'howMany',
+      'spellcheck': False,
+    },
+  }
+---
+# name: TestNumberInput.test_govuk_input
+  <class 'dict'> {
+    'classes': 'app-text-input--height-compatible govuk-input--width-5',
+    'id': 'input-howMany',
+    'name': 'howMany',
+    'spellcheck': False,
+  }
+---
 # name: TestRadios.test_from_question
   <class 'dict'> {
     'idPrefix': 'input-yesOrNo',

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -351,6 +351,7 @@
     'id': 'input-description',
     'maxwords': 100,
     'name': 'description',
+    'spellcheck': True,
   }
 ---
 # name: TestGovukCharacterCount.test_govuk_character_count
@@ -361,6 +362,7 @@
     'id': 'input-description',
     'maxwords': 100,
     'name': 'description',
+    'spellcheck': True,
   }
 ---
 # name: TestGovukCharacterCount.test_with_data
@@ -379,6 +381,7 @@
       'id': 'input-description',
       'maxwords': 100,
       'name': 'description',
+      'spellcheck': True,
       'value': 'The specialist must know how to make tea and work well with unicorns.',
     },
   }
@@ -402,6 +405,7 @@
       'id': 'input-description',
       'maxwords': 100,
       'name': 'description',
+      'spellcheck': True,
     },
   }
 ---

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -477,6 +477,11 @@ class TestGovukCharacterCount:
     def test_govuk_character_count(self, question, snapshot):
         assert govuk_character_count(question) == snapshot
 
+    def test_govuk_character_count_spellcheck_is_true(self, question):
+        params = govuk_character_count(question)
+
+        assert params["spellcheck"] is True
+
     def test_from_question(self, question, snapshot):
         form = from_question(question)
 

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -65,6 +65,122 @@ class TestTextInput:
         assert from_question(question, errors=errors) == snapshot
 
 
+class TestNumberInput:
+    @pytest.fixture
+    def question(self):
+        return Question({
+            "id": "howMany",
+            "question": "How many?",
+            "type": "number",
+        })
+
+    def test_govuk_input(self, question, snapshot):
+        assert govuk_input(question) == snapshot
+
+    def test_govuk_input_asking_for_whole_numbers(self, question):
+        """Test that we follow Design System guidance on asking for numbers
+
+        https://design-system.service.gov.uk/components/text-input/#numbers
+        """
+
+        question.limits = {"integer_only": True}
+
+        params = govuk_input(question)
+
+        assert params["inputmode"] == "numeric"
+        assert params["pattern"] == "[0-9]*"
+        assert params["spellcheck"] is False
+
+    @pytest.mark.parametrize("integer_only", (False, None))
+    def test_govuk_input_asking_for_decimal_numbers(self, integer_only, question):
+        """Test that we follow Design System guidance on asking for numbers
+
+        https://design-system.service.gov.uk/components/text-input/#numbers
+        """
+
+        if integer_only is False:
+            question.limits = {"integer_only": False}
+
+        params = govuk_input(question)
+
+        assert "inputmode" not in params
+        assert params["spellcheck"] is False
+
+    def test_govuk_input_prefix(self, question):
+        question.unit = "£"
+        question.unit_position = "before"
+
+        params = govuk_input(question)
+
+        assert params["prefix"] == {"text": "£"}
+
+    def test_govuk_input_suffix(self, question):
+        question.unit = "%"
+        question.unit_position = "after"
+
+        params = govuk_input(question)
+
+        assert params["suffix"] == {"text": "%"}
+
+    @pytest.mark.parametrize(
+        "unit, unit_position, expected_pattern",
+        (
+            ("%", "after", "[0-9]*%?"),
+            ("£", "before", "£?[0-9]*"),
+        ),
+    )
+    def test_govuk_input_pattern_includes_prefix_or_suffix(
+        self,
+        unit,
+        unit_position,
+        expected_pattern,
+        question,
+    ):
+        question.limits = {"integer_only": True}
+
+        question.unit = unit
+        question.unit_position = unit_position
+
+        params = govuk_input(question)
+
+        assert params["pattern"] == expected_pattern
+
+    def test_govuk_input_width(self, question):
+        """Number inputs should be a reasonably small width"""
+        params = govuk_input(question)
+        assert "govuk-input--width-5" in params["classes"]
+
+    def test_from_question(self, question, snapshot):
+        form = from_question(question)
+
+        assert "label" in form
+        assert form["macro_name"] == "govukInput"
+        assert form["params"] == snapshot
+
+    def test_from_question_with_data(self, question, snapshot):
+        data = {"howMany": "10"}
+
+        form = from_question(question, data)
+
+        assert form["params"]["value"] == "10"
+        assert form == snapshot
+
+    def test_from_question_with_errors(self, question, snapshot):
+        errors = {
+            "howMany": {
+                "input_name": "howMany",
+                "href": "#input-howMany",
+                "question": "How many?",
+                "message": "Enter how many",
+            }
+        }
+
+        form = from_question(question, errors=errors)
+
+        assert "errorMessage" in form["params"]
+        assert form == snapshot
+
+
 class TestRadios:
     @pytest.fixture
     def question(self):


### PR DESCRIPTION
Ticket: https://trello.com/c/0cIr1131/210-2-replace-number-type-questions-in-create-a-dos-opportunity-journey

We can now use GOV.UK Frontend text input components for number questions.

### Screenshots

#### Before

<img width="765" alt="Screenshot 2020-09-02 at 15 47 47" src="https://user-images.githubusercontent.com/503614/91998876-af657b80-ed33-11ea-9ae9-6c600dbe5c79.png">

#### After

<img width="687" alt="Screenshot 2020-09-02 at 15 46 55" src="https://user-images.githubusercontent.com/503614/91998805-98bf2480-ed33-11ea-9590-bbbf80975e06.png">