### PR TITLE
Add height compatible override class to date input inputs

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.19.0'
+__version__ = '7.19.1'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -152,15 +152,15 @@ def govuk_date_input(
     params["items"] = [
         {
             "name": "day",
-            "classes": "govuk-input--width-2"
+            "classes": "app-text-input--height-compatible govuk-input--width-2"
         },
         {
             "name": "month",
-            "classes": "govuk-input--width-2"
+            "classes": "app-text-input--height-compatible govuk-input--width-2"
         },
         {
             "name": "year",
-            "classes": "govuk-input--width-4"
+            "classes": "app-text-input--height-compatible govuk-input--width-4"
         }
     ]
 

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -101,15 +101,15 @@
     'id': 'input-startDate',
     'items': <class 'list'> [
       <class 'dict'> {
-        'classes': 'govuk-input--width-2',
+        'classes': 'app-text-input--height-compatible govuk-input--width-2',
         'name': 'day',
       },
       <class 'dict'> {
-        'classes': 'govuk-input--width-2',
+        'classes': 'app-text-input--height-compatible govuk-input--width-2',
         'name': 'month',
       },
       <class 'dict'> {
-        'classes': 'govuk-input--width-4',
+        'classes': 'app-text-input--height-compatible govuk-input--width-4',
         'name': 'year',
       },
     ],
@@ -131,17 +131,17 @@
       'id': 'input-startDate',
       'items': <class 'list'> [
         <class 'dict'> {
-          'classes': 'govuk-input--width-2',
+          'classes': 'app-text-input--height-compatible govuk-input--width-2',
           'name': 'day',
           'value': 1,
         },
         <class 'dict'> {
-          'classes': 'govuk-input--width-2',
+          'classes': 'app-text-input--height-compatible govuk-input--width-2',
           'name': 'month',
           'value': 12,
         },
         <class 'dict'> {
-          'classes': 'govuk-input--width-4',
+          'classes': 'app-text-input--height-compatible govuk-input--width-4',
           'name': 'year',
           'value': 2020,
         },
@@ -168,15 +168,15 @@
       'id': 'input-startDate',
       'items': <class 'list'> [
         <class 'dict'> {
-          'classes': 'govuk-input--width-2 govuk-input--error',
+          'classes': 'app-text-input--height-compatible govuk-input--width-2 govuk-input--error',
           'name': 'day',
         },
         <class 'dict'> {
-          'classes': 'govuk-input--width-2 govuk-input--error',
+          'classes': 'app-text-input--height-compatible govuk-input--width-2 govuk-input--error',
           'name': 'month',
         },
         <class 'dict'> {
-          'classes': 'govuk-input--width-4 govuk-input--error',
+          'classes': 'app-text-input--height-compatible govuk-input--width-4 govuk-input--error',
           'name': 'year',
         },
       ],
@@ -199,15 +199,15 @@
     'id': 'input-startDate',
     'items': <class 'list'> [
       <class 'dict'> {
-        'classes': 'govuk-input--width-2',
+        'classes': 'app-text-input--height-compatible govuk-input--width-2',
         'name': 'day',
       },
       <class 'dict'> {
-        'classes': 'govuk-input--width-2',
+        'classes': 'app-text-input--height-compatible govuk-input--width-2',
         'name': 'month',
       },
       <class 'dict'> {
-        'classes': 'govuk-input--width-4',
+        'classes': 'app-text-input--height-compatible govuk-input--width-4',
         'name': 'year',
       },
     ],

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -355,6 +355,12 @@ class TestDateInput:
 
         assert params["namePrefix"] == question.id
 
+    def test_govuk_date_input_classes(self, question):
+        params = govuk_date_input(question)
+
+        for item in params["items"]:
+            assert "app-text-input--height-compatible" in item["classes"]
+
     def test_from_question(self, question, snapshot):
         form = from_question(question)
 


### PR DESCRIPTION
We want to make sure the inputs are all the same height in our apps.

### Screenshots

#### After

![image](https://user-images.githubusercontent.com/503614/92250251-241af000-eec3-11ea-9056-abc492c5ed8d.png)
