### PR TITLE
Add dm_pricing_input to govuk_frontend

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.19.1'
+__version__ = '7.20.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -107,12 +107,12 @@ def from_question(
 def govuk_input(
     question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
-    """Create govukInput macro parameters from a text or number question"""
+    """Create govukInput macro parameters from a text, number or pricing question"""
 
     kwargs.setdefault("classes", ["app-text-input--height-compatible"])
     params = _params(question, data, errors, **kwargs)
 
-    if question.type == "number":
+    if question.type in ("number", "pricing"):
         params["classes"] += " govuk-input--width-5"
         params["spellcheck"] = False
         if question.get("limits") and question.limits.get("integer_only") is True:

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -71,7 +71,9 @@ def from_question(
             "macro_name": "govukInput",
             "params": govuk_input(question, data, errors, **kwargs),
         }
-    if question.type == "date":
+    elif question.type == "pricing":
+        return dm_pricing_input(question, data, errors, **kwargs)
+    elif question.type == "date":
         return {
             "fieldset": govuk_fieldset(question, **kwargs),
             "macro_name": "govukDateInput",
@@ -229,6 +231,37 @@ def dm_list_input(
             )
 
     return params
+
+
+def dm_pricing_input(
+    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+) -> dict:
+    """Create several parameters for several components based on fields in pricing question"""
+
+    if data is None:
+        data = {}
+
+    # There can either be multiple fields from the set {"maximum_price",
+    # "minimum_price", "pricing_unit", "pricing_interval"}, or a single field
+    # "price". If there is just a price field we don't want a fieldset.
+    if len(question.fields) == 1:
+        return {
+            "label": govuk_label(question, **kwargs),
+            "macro_name": "govukInput",
+            "params": govuk_input(
+                question,
+                data,
+                errors,
+                input_id=question.fields["price"],
+                prefix_text="£",
+            ),
+        }
+
+    # TODO: Handle pricing questions with multiple fields. For now (for the
+    # briefs frontend) we only need to handle the simple case. Have a look at
+    # branch ldeb-spike-pricing-input-multiple-fields for a sketch of how to do
+    # the multiple field case.
+    raise NotImplementedError("cannot yet handle pricing question with multiple fields")
 
 
 def govuk_label(question: Question, *, is_page_heading: bool = True, **kwargs) -> dict:

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -343,6 +343,90 @@
     },
   }
 ---
+# name: TestDmPricingInput.test_dm_pricing_input_with_price_field
+  <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-cost',
+      'isPageHeading': True,
+      'text': "What's the cost?",
+    },
+    'macro_name': 'govukInput',
+    'params': <class 'dict'> {
+      'classes': 'app-text-input--height-compatible govuk-input--width-5',
+      'id': 'input-cost',
+      'name': 'cost',
+      'prefix': <class 'dict'> {
+        'text': '£',
+      },
+      'spellcheck': False,
+    },
+  }
+---
+# name: TestDmPricingInput.test_from_question[price_question]
+  <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-cost',
+      'isPageHeading': True,
+      'text': "What's the cost?",
+    },
+    'macro_name': 'govukInput',
+    'params': <class 'dict'> {
+      'classes': 'app-text-input--height-compatible govuk-input--width-5',
+      'id': 'input-cost',
+      'name': 'cost',
+      'prefix': <class 'dict'> {
+        'text': '£',
+      },
+      'spellcheck': False,
+    },
+  }
+---
+# name: TestDmPricingInput.test_from_question_with_data[price_question]
+  <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-cost',
+      'isPageHeading': True,
+      'text': "What's the cost?",
+    },
+    'macro_name': 'govukInput',
+    'params': <class 'dict'> {
+      'classes': 'app-text-input--height-compatible govuk-input--width-5',
+      'id': 'input-cost',
+      'name': 'cost',
+      'prefix': <class 'dict'> {
+        'text': '£',
+      },
+      'spellcheck': False,
+      'value': '1.00',
+    },
+  }
+---
+# name: TestDmPricingInput.test_from_question_with_errors[price_question]
+  <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-cost',
+      'isPageHeading': True,
+      'text': "What's the cost?",
+    },
+    'macro_name': 'govukInput',
+    'params': <class 'dict'> {
+      'classes': 'app-text-input--height-compatible govuk-input--width-5',
+      'errorMessage': <class 'dict'> {
+        'text': 'Enter a cost.',
+      },
+      'id': 'input-cost',
+      'name': 'cost',
+      'prefix': <class 'dict'> {
+        'text': '£',
+      },
+      'spellcheck': False,
+    },
+  }
+---
 # name: TestGovukCharacterCount.test_from_question
   <class 'dict'> {
     'hint': <class 'dict'> {

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -33,6 +33,10 @@ class TestTextInput:
     def test_govuk_input(self, question, snapshot):
         assert govuk_input(question) == snapshot
 
+    def test_govuk_input_classes(self, question, snapshot):
+        assert govuk_input(question)["classes"] == "app-text-input--height-compatible"
+        assert govuk_input(question, classes=["app-input"])["classes"] == "app-input"
+
     def test_from_question(self, question, snapshot):
         form = from_question(question)
 
@@ -114,11 +118,21 @@ class TestNumberInput:
 
         assert params["prefix"] == {"text": "£"}
 
+    def test_govuk_input_prefix_text_kwarg(self, question):
+        params = govuk_input(question, prefix_text="£")
+
+        assert params["prefix"] == {"text": "£"}
+
     def test_govuk_input_suffix(self, question):
         question.unit = "%"
         question.unit_position = "after"
 
         params = govuk_input(question)
+
+        assert params["suffix"] == {"text": "%"}
+
+    def test_govuk_input_suffix_text_kwarg(self, question):
+        params = govuk_input(question, suffix_text="%")
 
         assert params["suffix"] == {"text": "%"}
 
@@ -530,6 +544,15 @@ class TestGovukLabel:
             "text": "Yes or no?",
         }
 
+    def test_input_id_kwarg(self, question):
+        assert govuk_label(question, input_id="q1")["for"] == "input-q1"
+
+    def test_label_classes_kwarg(self, question):
+        assert "app-label" in govuk_label(question, label_classes=["app-label"])["classes"]
+
+    def test_label_text_kwarg(self, question):
+        assert govuk_label(question, label_text="This is a label")["text"] == "This is a label"
+
     def test_is_page_heading_false_removes_classes_and_ispageheading(self, question):
         assert govuk_label(question, is_page_heading=False) == {
             "for": "input-question",
@@ -593,12 +616,26 @@ class TestParams:
             "name": "question",
         }
 
+    def test_classes_kwarg(self, question):
+        assert _params(question, classes=["app-input"])["classes"] == "app-input"
+        assert _params(question, classes=["app-input", "app-input--l"])["classes"] == "app-input app-input--l"
+
+    def test_input_id_kwarg(self, question):
+        params = _params(question, input_id="question")
+        assert params["id"] == "input-question"
+        assert params["name"] == "question"
+
     def test_hint(self, question):
         question.hint = "Answer yes or no"
 
         assert _params(question)["hint"] == {
             "text": "Answer yes or no",
         }
+
+    def test_hint_classes_kwarg(self, question):
+        question.hint = "Choose yes or no"
+
+        assert _params(question, hint_classes=["app-hint"])["hint"]["classes"] == "app-hint"
 
     def test_value_is_present_if_question_answer_is_in_data(self, question):
         data = {"question": "Yes"}


### PR DESCRIPTION
https://trello.com/c/oIEbMdvM/213-2-replace-pricing-type-questions-in-create-a-dos-opportunity-journey

This only handles the case where the pricing question has a single field `price`, as this is the only case found in the briefs frontend. However I've taken some care to make sure the design will extend to the multiple fields case.

Like with the number field, this commit includes the params for a prefix, but they won't show up until https://github.com/alphagov/govuk-frontend/issues/1915 is closed.

### Screenshots

#### After

<img width="514" src="https://user-images.githubusercontent.com/503614/92256180-4d3f7e80-eecb-11ea-9b5f-9aadce5679a2.png">

#### Before

<img width="514" alt="Screenshot 2020-09-04 at 15 23 57" src="https://user-images.githubusercontent.com/503614/92255033-ab6b6200-eec9-11ea-8bba-f5d642490e9a.png">
