### PR TITLE
Add feature flag to Question to change behaviour of href

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.20.1'
+__version__ = '7.21.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -19,6 +19,10 @@ if TYPE_CHECKING:
 
 __all__ = ["from_question", "govuk_input", "govuk_label"]
 
+# Version of govuk-frontend templates expected. This is just the default,
+# set this in your app to change the behaviour of this code.
+govuk_frontend_version = (2, 13, 0)
+
 
 def from_question(
     question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
@@ -331,6 +335,11 @@ def get_href(question: 'Question', **kwargs) -> str:
 
     if question_type == "date":
         href = f"{href}-day"
+
+    # govuk-frontend version 3 and up doesn't have suffixes for the first
+    # input of a fieldset by default, so we can skip this logic
+    if govuk_frontend_version[0] >= 3:
+        return href
 
     if question_type in ("checkboxes", "list", "radios"):
         href = f"{href}-1"

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -8,19 +8,20 @@ content loader Question.
 Read the docstring for `from_question` for more detail on how this works.
 """
 
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 from dmutils.forms.errors import govuk_error
 from dmutils.forms.helpers import govuk_options
 
-from dmcontent.questions import Question
+if TYPE_CHECKING:
+    from dmcontent.questions import Question
 
 
 __all__ = ["from_question", "govuk_input", "govuk_label"]
 
 
 def from_question(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+    question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> Optional[dict]:
     """Create parameters object for govuk-frontend macros from a question
 
@@ -107,7 +108,7 @@ def from_question(
 
 
 def govuk_input(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+    question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
     """Create govukInput macro parameters from a text, number or pricing question"""
 
@@ -142,7 +143,7 @@ def govuk_input(
 
 
 def govuk_checkboxes(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+    question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
     """Create govukCheckboxes macro parameters from a checkboxes question"""
 
@@ -150,7 +151,7 @@ def govuk_checkboxes(
 
 
 def govuk_date_input(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+    question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
     """Create govukDateInput macro parameters from a date question"""
 
@@ -185,7 +186,7 @@ def govuk_date_input(
 
 
 def govuk_radios(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+    question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
     """Create govukRadios macro parameters from a radios question"""
 
@@ -205,7 +206,7 @@ def govuk_radios(
 
 
 def dm_list_input(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+    question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
     """Create dmListInput macro parameters from a list question"""
 
@@ -234,7 +235,7 @@ def dm_list_input(
 
 
 def dm_pricing_input(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+    question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
     """Create several parameters for several components based on fields in pricing question"""
 
@@ -264,7 +265,7 @@ def dm_pricing_input(
     raise NotImplementedError("cannot yet handle pricing question with multiple fields")
 
 
-def govuk_label(question: Question, *, is_page_heading: bool = True, **kwargs) -> dict:
+def govuk_label(question: 'Question', *, is_page_heading: bool = True, **kwargs) -> dict:
     """
     :param bool is_page_heading: If True, the label will be set to display as a page heading
     """
@@ -285,7 +286,7 @@ def govuk_label(question: Question, *, is_page_heading: bool = True, **kwargs) -
     return label
 
 
-def govuk_fieldset(question: Question, *, is_page_heading: bool = True, **kwargs) -> dict:
+def govuk_fieldset(question: 'Question', *, is_page_heading: bool = True, **kwargs) -> dict:
     """
     :param bool is_page_heading: If True, the legend will be set to display as a page heading
     """
@@ -305,7 +306,7 @@ def govuk_fieldset(question: Question, *, is_page_heading: bool = True, **kwargs
 
 
 def govuk_character_count(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+    question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
     params = _params(question, data, errors)
 
@@ -317,7 +318,27 @@ def govuk_character_count(
     return params
 
 
-def get_label_text(question: Question, **kwargs) -> str:
+def get_href(question: 'Question', **kwargs) -> str:
+    """The default url fragment for a question's input field."""
+    # This code unfortunately couples us to the template used to render the question
+    # TODO: be better
+    href = f"#input-{question.id}"
+
+    question_type = question.get("type")
+
+    if question_type == "checkbox_tree":
+        href = f"{href}-1-1"
+
+    if question_type == "date":
+        href = f"{href}-day"
+
+    if question_type in ("checkboxes", "list", "radios"):
+        href = f"{href}-1"
+
+    return href
+
+
+def get_label_text(question: 'Question', **kwargs) -> str:
     label_text = kwargs.get("label_text", question.question)
     if question.is_optional:
         # GOV.UK Design System says
@@ -328,7 +349,7 @@ def get_label_text(question: Question, **kwargs) -> str:
 
 
 def _params(
-    question: Question, data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+    question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
 ) -> dict:
     """Common parameters for govuk-frontent components
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -9,6 +9,7 @@ from dmutils.formats import DATE_FORMAT, DISPLAY_DATE_FORMAT
 from .converters import convert_to_boolean, convert_to_number
 from .errors import ContentNotFoundError
 from .formats import format_price
+from .govuk_frontend import get_href
 from .utils import TemplateField, drop_followups, get_option_value
 
 
@@ -143,22 +144,7 @@ class Question(object):
     @property
     def href(self):
         """Return the URL fragment for the first input element for this question"""
-        # This code unfortunately couples us to the template used to render the question
-        # TODO: be better
-        href = f"#input-{self.id}"
-
-        question_type = self.get("type")
-
-        if question_type in ("checkboxes", "list", "radios"):
-            href = f"{href}-1"
-
-        if question_type == "checkbox_tree":
-            href = f"{href}-1-1"
-
-        if question_type == "date":
-            href = f"{href}-day"
-
-        return href
+        return get_href(self)
 
     @property
     def label(self):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -6,9 +6,10 @@ import pytest
 import six
 from werkzeug.datastructures import OrderedMultiDict
 
+import dmcontent.govuk_frontend
+from dmcontent import ContentTemplateError
 from dmcontent.content_loader import ContentQuestion
 from dmcontent.utils import TemplateField
-from dmcontent import ContentTemplateError
 
 
 class QuestionTest(object):
@@ -143,6 +144,15 @@ class QuestionTest(object):
             assert href.endswith("-1-1")
         elif question.type == "date":
             assert href.endswith("-day")
+
+    def test_question_href_property_govuk_frontend_v3(self, monkeypatch):
+        monkeypatch.setattr(dmcontent.govuk_frontend, "govuk_frontend_version", (3,), raising=False)
+
+        question = self.question()
+
+        href = question.href
+        if question.type in ("checkboxes", "list", "radios"):
+            assert not href.endswith("-1")
 
 
 class TestText(QuestionTest):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -132,6 +132,18 @@ class QuestionTest(object):
                     if subfield in item:
                         assert type(item[subfield]) == Markup
 
+    def test_question_has_href_property(self):
+        question = self.question()
+
+        href = question.href
+        assert href.startswith("#input-")
+        if question.type in ("checkboxes", "list", "radios"):
+            assert href.endswith("-1")
+        elif question.type == "checkbox_tree":
+            assert href.endswith("-1-1")
+        elif question.type == "date":
+            assert href.endswith("-day")
+
 
 class TestText(QuestionTest):
     def question(self, **kwargs):


### PR DESCRIPTION
If an app is using govuk-frontend version 3 and up we don't want the href to end with a `-1`, as that is not what the template will output.

To use this an app should set `dmcontent.govuk_frontend.govuk_frontend_version` at some point early on in the loading process.