### PR TITLE
Add GitHub Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot config
+# https://dependabot.com/docs/config-file/
+# Checks and updates dependencies in
+# `requirements.in`, `requirements.txt`,
+# and `setup.py`
+
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "03:00"
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
I'm trying an experiment into managing library dependencies using Dependabot, for the open RFC https://docs.google.com/document/d/1i3Pz29C1M1C0G51q6P2QWSy85oolneOcFiEdwDo74oo/