### PR TITLE
Add support for pricing without minima

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.21.0'
+__version__ = '7.22.0'

--- a/dmcontent/formats.py
+++ b/dmcontent/formats.py
@@ -1,16 +1,31 @@
 # -*- coding: utf-8 -*-
+from typing import Optional, Union
 
 
-def format_price(min_price, max_price, unit, interval, hours_for_price=None):
+def format_price(min_price: Optional[Union[str, float]],
+                 max_price: Optional[Union[str, float]],
+                 unit: Optional[str],
+                 interval: Optional[str],
+                 hours_for_price: Optional[str] = None):
     """Format a price string"""
-    if hours_for_price:
-        return u'{} for £{}'.format(hours_for_price, min_price)
+    if min_price is not None:
+        min_price = str(min_price)
+    if max_price is not None:
+        max_price = str(max_price)
 
-    if min_price is None:
-        raise TypeError('min_price should be string or integer, not None')
-    formatted_price = u'£{}'.format(min_price)
+    if not (min_price or max_price):
+        raise TypeError('One of min_price or max_price should be number or non-empty string, not None')
+
+    if hours_for_price:
+        return u'{} for £{}'.format(hours_for_price, min_price or max_price)
+
+    formatted_price = ""
+    if min_price:
+        formatted_price += u'£{}'.format(min_price)
+    if min_price and max_price:
+        formatted_price += u' to '
     if max_price:
-        formatted_price += u' to £{}'.format(max_price)
+        formatted_price += u'£{}'.format(max_price)
     if unit:
         formatted_price += ' per ' + unit.lower()
     if interval:

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -811,7 +811,7 @@ class PricingSummary(QuestionSummary, Pricing):
         hours_for_price = self._service_data.get(self.fields.get('hours_for_price'),
                                                  self._default_for_field('hours_for_price'))
 
-        if price or minimum_price:
+        if price or minimum_price or maximum_price:
             return format_price(price or minimum_price, maximum_price, price_unit, price_interval, hours_for_price)
         else:
             return ''

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -11,14 +11,26 @@ import pytest
     ((12, 13, 'Unit', None), u'£12 to £13 per unit'),
     (('34', None, 'Lab', None, '4 hours'), u'4 hours for £34'),
     (('12', None, None, None), u'£12'),
+    ((0, None, None, None), u'£0'),
+    (('12', "", None, None), u'£12'),
+    (('12', None, None, 'Second'), '£12 per second'),
+    ((None, '12', None, None), '£12'),
+    ((None, 0, None, None), '£0'),
+    (("", '12', None, None), '£12'),
 ])
 def test_format_price(args, formatted_price):
     assert format_price(*args) == formatted_price
 
 
-def test_format_price_errors():
-    with pytest.raises((TypeError, AttributeError)):
-        format_price(*(None, None, None, None))
+@pytest.mark.parametrize('args', [
+    (None, None, None, None),
+    (None, None, 'Unit', 'Second'),
+    (None, "", 'Unit', 'Second'),
+    ("", None, 'Unit', 'Second'),
+])
+def test_format_price_errors(args):
+    with pytest.raises(TypeError):
+        format_price(*args)
 
 
 @pytest.mark.parametrize('price_min, formatted_price', [

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -317,6 +317,9 @@ class TestPricing(QuestionTest):
             {'priceMax': '20'}
         ) == {'priceMax': '20'}
 
+    def test_no_minimum(self):
+        assert self.question().summary({'priceMax': '20'}).value == "£20"
+
     def test_form_fields(self):
         assert sorted(self.question().form_fields) == sorted(['priceMin', 'priceMax'])
 
@@ -1199,8 +1202,8 @@ class TestPricingSummary(QuestionSummaryTest):
 
     @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
     def test_value_without_price_min(self, summary_inplace_allowed):
-        question = self.question().summary({'priceMax': '25.00'}, inplace_allowed=summary_inplace_allowed)
-        assert question.value == ''
+        question = self.question().summary({'priceMax': '25.01'}, inplace_allowed=summary_inplace_allowed)
+        assert question.value == '£25.01'
 
     @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
     def test_value_price_field(self, summary_inplace_allowed):


### PR DESCRIPTION
Trello: https://trello.com/c/yWkgqyPL/325-2-update-dos5-application-content-in-the-frameworks-repo

In DOS 5, we will only have the maximum. Update the summary so this gets handled correctly. Add tests to verify. Add in some type hints for fun.

I am assuming that nothing that currently exists relies on the previous behaviour. As far as I can tell, form verification ensures that the minimum is provided where it is needed.