### PR TITLE
Replace 'per' with 'a'

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.22.0'
+__version__ = '7.23.0'

--- a/dmcontent/formats.py
+++ b/dmcontent/formats.py
@@ -27,9 +27,9 @@ def format_price(min_price: Optional[Union[str, float]],
     if max_price:
         formatted_price += u'£{}'.format(max_price)
     if unit:
-        formatted_price += ' per ' + unit.lower()
+        formatted_price += ' a ' + unit.lower()
     if interval:
-        formatted_price += ' per ' + interval.lower()
+        formatted_price += ' a ' + interval.lower()
     return formatted_price
 
 

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -418,7 +418,7 @@ class TestContentManifest(object):
         assert summary.get_question('q4').assurance == ''  # question without assurance returns an empty string
         assert summary.get_question('q5').answer_required
         assert not summary.get_question('q6').answer_required
-        assert summary.get_question('q7').value == u'£10 per day'
+        assert summary.get_question('q7').value == u'£10 a day'
         assert not summary.get_question('q7').answer_required
         assert summary.get_question('q8').answer_required
         assert not summary.get_question('q9').answer_required

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -4,16 +4,16 @@ import pytest
 
 
 @pytest.mark.parametrize('args, formatted_price', [
-    ((u'12', None, 'Unit', None), u'£12 per unit'),
-    (('12', '13', 'Unit', None), u'£12 to £13 per unit'),
-    (('12', '13', 'Unit', 'Second'), u'£12 to £13 per unit per second'),
-    (('12', None, 'Unit', 'Second'), u'£12 per unit per second'),
-    ((12, 13, 'Unit', None), u'£12 to £13 per unit'),
+    ((u'12', None, 'Unit', None), u'£12 a unit'),
+    (('12', '13', 'Unit', None), u'£12 to £13 a unit'),
+    (('12', '13', 'Unit', 'Second'), u'£12 to £13 a unit a second'),
+    (('12', None, 'Unit', 'Second'), u'£12 a unit a second'),
+    ((12, 13, 'Unit', None), u'£12 to £13 a unit'),
     (('34', None, 'Lab', None, '4 hours'), u'4 hours for £34'),
     (('12', None, None, None), u'£12'),
     ((0, None, None, None), u'£0'),
     (('12', "", None, None), u'£12'),
-    (('12', None, None, 'Second'), '£12 per second'),
+    (('12', None, None, 'Second'), '£12 a second'),
     ((None, '12', None, None), '£12'),
     ((None, 0, None, None), '£0'),
     (("", '12', None, None), '£12'),
@@ -34,7 +34,7 @@ def test_format_price_errors(args):
 
 
 @pytest.mark.parametrize('price_min, formatted_price', [
-    ('12.12', u'£12.12 to £13.13 per unit per second'),
+    ('12.12', u'£12.12 to £13.13 a unit a second'),
     ('', ''),
     (None, ''),
 ])

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -1229,7 +1229,7 @@ class TestPricingSummary(QuestionSummaryTest):
             {'priceMin': '20.41', 'priceMax': '25.00', 'priceUnit': 'service'},
             inplace_allowed=summary_inplace_allowed,
         )
-        assert question.value == u'£20.41 to £25.00 per service'
+        assert question.value == u'£20.41 to £25.00 a service'
 
     @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
     def test_value_with_interval(self, summary_inplace_allowed):
@@ -1237,7 +1237,7 @@ class TestPricingSummary(QuestionSummaryTest):
             {'priceMin': '20.41', 'priceMax': '25.00', 'priceInterval': 'day'},
             inplace_allowed=summary_inplace_allowed,
         )
-        assert question.value == u'£20.41 to £25.00 per day'
+        assert question.value == u'£20.41 to £25.00 a day'
 
     @pytest.mark.parametrize("summary_inplace_allowed", (False, True,))
     def test_value_with_unit_and_interval(self, summary_inplace_allowed):
@@ -1245,7 +1245,7 @@ class TestPricingSummary(QuestionSummaryTest):
             {'priceMin': '20.41', 'priceMax': '25.00', 'priceUnit': 'service', 'priceInterval': 'day'},
             inplace_allowed=summary_inplace_allowed,
         )
-        assert question.value == u'£20.41 to £25.00 per service per day'
+        assert question.value == u'£20.41 to £25.00 a service a day'
 
 
 class TestMultiquestionSummary(QuestionSummaryTest):


### PR DESCRIPTION
Trello: https://trello.com/c/yWkgqyPL/325-2-update-dos5-application-content-in-the-frameworks-repo

As [recommended](https://trello.com/c/WlpUAQZe/327-1-update-supplier-fe-content-for-dos5-application-journey#comment-5f64a5e2b98036851c51ea1b) by the recent accessibility review. Matches changes already made in https://github.com/alphagov/digitalmarketplace-frameworks/pull/635