### PR TITLE
Start testing against Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - make requirements-dev
 script:

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -80,9 +80,9 @@ class TemplateField(object):
 def template_all(item):
     if isinstance(item, str):
         return TemplateField(item)
-    elif isinstance(item, collections.Sequence):
+    elif isinstance(item, collections.abc.Sequence):
         return [template_all(i) for i in item]
-    elif isinstance(item, collections.Mapping):
+    elif isinstance(item, collections.abc.Mapping):
         result = {}
         for (key, val) in item.items():
             result[key] = template_all(val)


### PR DESCRIPTION
And fix a DeprecationWarning: "Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working"
