### PR TITLE
Update Markdown requirement to latest major version

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.23.0'
+__version__ = '7.24.0'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ docopt==0.6.2             # via -c requirements.txt, coveralls
 entrypoints==0.3          # via flake8
 flake8==3.7.9             # via -r requirements-dev.in
 idna==2.10                # via -c requirements.txt, requests
-importlib-metadata==1.7.0  # via pluggy, pytest
+importlib-metadata==2.0.0  # via -c requirements.txt, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 mccabe==0.6.1             # via flake8
 mock==4.0.2               # via -r requirements-dev.in
@@ -35,7 +35,7 @@ syrupy==0.6.1             # via -r requirements-dev.in
 toml==0.10.1              # via pytest
 typing-extensions==3.7.4.2  # via syrupy
 urllib3==1.25.10          # via -c requirements.txt, requests
-zipp==3.1.0               # via importlib-metadata
+zipp==3.3.0               # via -c requirements.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,12 +29,13 @@ future==0.18.2            # via notifications-python-client
 gds-metrics==0.2.4        # via digitalmarketplace-utils
 govuk-country-register==0.5.0  # via digitalmarketplace-utils
 idna==2.10                # via cryptography, requests
+importlib-metadata==2.0.0  # via markdown
 inflection==0.5.1         # via digitalmarketplace-content-loader
 itsdangerous==1.1.0       # via flask, flask-wtf
 jinja2==2.11.2            # via digitalmarketplace-content-loader, flask
 jmespath==0.10.0          # via boto3, botocore
 mailchimp3==3.0.6         # via digitalmarketplace-utils
-markdown==2.6.11          # via digitalmarketplace-content-loader
+markdown==3.3             # via digitalmarketplace-content-loader
 markupsafe==1.1.1         # via jinja2, wtforms
 monotonic==1.5            # via notifications-python-client
 notifications-python-client==5.7.0  # via digitalmarketplace-utils
@@ -54,3 +55,4 @@ urllib3==1.25.10          # via botocore, requests
 werkzeug==1.0.1           # via digitalmarketplace-utils, flask
 workdays==1.4             # via digitalmarketplace-utils
 wtforms==2.3.3            # via flask-wtf
+zipp==3.3.0               # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         'Flask<1.1.0,>=1.0.2',
         'Jinja2<2.12,>=2.10',
-        'Markdown<3.0.0,>=2.6.7',
+        'Markdown<4.0.0,>=2.6.7',
         'PyYAML<6.0,>=5.1.2',
         'inflection<1.0.0,>=0.3.1',
         'digitalmarketplace-utils>=52.9.0',

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,36 @@
+import markdown
+
+from dmcontent.markdown import GOVUKFrontendExtension
+
+
+class TestGOVUKFrontendExtension:
+    def test_is_python_markdown_extension(self):
+        assert markdown.Markdown(extensions=[GOVUKFrontendExtension()])
+
+    def test_it_adds_govuk_design_system_styles(self):
+        text = """
+## Headings
+
+1. ordered lists
+
+Paragraphs, and [links](#).
+
+- bullet lists
+"""
+
+        assert (
+            markdown.markdown(text, extensions=[GOVUKFrontendExtension()])
+            == """<h2 class="govuk-heading-m">Headings</h2>
+<ol class="govuk-list govuk-list--number">
+<li>ordered lists</li>
+</ol>
+<p class="govuk-body">Paragraphs, and <a class="govuk-link" href="#">links</a>.</p>
+<ul class="govuk-list govuk-list--bullet">
+<li>bullet lists</li>
+</ul>"""
+        )
+
+    def test_it_does_not_change_existing_html(self):
+        text = '<a href="#" target="_blank" rel="noopener noreferrer">link (opens in new tab)</a>'
+
+        assert text in markdown.markdown(text, extensions=[GOVUKFrontendExtension()])


### PR DESCRIPTION
We want to be able to keep up to date with [Python-Markdown](https://pypi.org/project/Markdown/), which is currently on version 3.3. Currently however we are constrained to use the latest 2 series version, which was released in 2018.

This PR adds tests to our Markdown extension so we can be sure nothing will break from upgrading, and lifts the upper bound on the requirement constraint.

This PR does not change the extension (although it uses some deprecated APIs) because that would be a breaking change, which we don't want right now.