### PR TITLE
Add remove prefix/suffix support to number type questions

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.24.0'
+__version__ = '7.25.0'

--- a/dmcontent/converters.py
+++ b/dmcontent/converters.py
@@ -24,7 +24,7 @@ def convert_to_boolean(value):
     return value
 
 
-def convert_to_number(value):
+def convert_to_number(value, *, prefix=None, suffix=None):
     """Turns numeric looking things into floats or ints
 
     Integery things should be integers
@@ -38,7 +38,16 @@ def convert_to_number(value):
     Other things should be unchanged
     >>> for value in [0, 'other', True, 123]:
     ...   assert convert_to_number(value) == value
+
+    :param str prefix: if present removes prefix from value
+    :param str suffix: if present removes suffix from value
     """
+
+    if prefix and value.startswith(prefix):
+        value = value[len(prefix):]
+    if suffix and value.endswith(suffix):
+        value = value[:-len(suffix)]
+
     try:
         return float(value) if "." in value else int(value)
     except (TypeError, ValueError):

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -84,7 +84,14 @@ class Question(object):
         elif self.type == 'boolean':
             value = convert_to_boolean(form_data[self.id])
         elif self.type == 'number':
-            value = convert_to_number(form_data[self.id])
+            kwargs = {}
+            if self.get("unit"):
+                if self.unit_position == "after":
+                    kwargs["suffix"] = self.unit
+                elif self.unit_position == "before":
+                    kwargs["prefix"] = self.unit
+
+            value = convert_to_number(form_data[self.id], **kwargs)
         elif self.type != 'upload':
             value = form_data[self.id]
         else:

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dmcontent.converters import convert_to_boolean, convert_to_number
 
 
@@ -24,6 +26,25 @@ def test_convert_to_number_converts_integer_looking_strings_into_floats():
 def test_convert_to_number_converts_floaty_looking_strings_into_floats():
     for number in ['0.99', '1.1', '1000.0000001']:
         assert isinstance(convert_to_number(number), float)
+
+
+@pytest.mark.parametrize("text, prefix, number", (
+    ("£0.99", "£", 0.99),
+    ("£ 12000", "£", 12000),
+))
+def test_convert_to_number_can_remove_prefixes(text, prefix, number):
+    assert convert_to_number(text, prefix=prefix) == number
+
+
+@pytest.mark.parametrize("text, suffix, number", (
+    ("98%", "%", 98),
+    ("45 %", "%", 45),
+    ("25.0%", "%", 25.0),
+    ("3p", "p", 3),
+    ("7 hours", "hours", 7),
+))
+def test_convert_to_number_can_remove_suffixes(text, suffix, number):
+    assert convert_to_number(text, suffix=suffix) == number
 
 
 def test_convert_to_number_leaves_other_things__unchanged():

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -571,6 +571,14 @@ class TestNumberQuestion(QuestionTest):
     def test_get_data(self):
         assert self.question().get_data({"example": "100"}) == {"example": 100}
 
+    def test_get_data_with_prefix(self):
+        question_with_prefix = self.question(unit="£", unit_position="before")
+        assert question_with_prefix.get_data({"example": "£20.50"}) == {"example": 20.5}
+
+    def test_get_data_with_suffix(self):
+        question_with_suffix = self.question(unit="%", unit_position="after")
+        assert question_with_suffix.get_data({"example": "50%"}) == {"example": 50}
+
 
 class TestDynamicListQuestion(QuestionTest):
     default_context = {'context': {'field': ['First Need', 'Second Need', 'Third Need', 'Fourth need']}}

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -557,6 +557,21 @@ class TestMultiquestion(QuestionTest):
         ])
 
 
+class TestNumberQuestion(QuestionTest):
+
+    def question(self, **kwargs):
+        data = {
+            "id": "example",
+            "type": "number"
+        }
+        data.update(kwargs)
+
+        return ContentQuestion(data)
+
+    def test_get_data(self):
+        assert self.question().get_data({"example": "100"}) == {"example": 100}
+
+
 class TestDynamicListQuestion(QuestionTest):
     default_context = {'context': {'field': ['First Need', 'Second Need', 'Third Need', 'Fourth need']}}
 


### PR DESCRIPTION
Ticket: https://trello.com/c/MwEMI2pR/428-fix-the-problem

We want to be able to gracefully handle the case where users input units into a form, following Design System guidance [[1]].

Now number type questions with a unit will be automatically filter those units from the user data.

The code to remove prefixes or suffixes is copied from [PEP-616][2], one day we might be able to replace it with the `removeprefix()` and `removesuffix()` methods.

[1]:
https://design-system.service.gov.uk/components/text-input/#prefixes-and-suffixes
[2]: https://www.python.org/dev/peps/pep-0616/