### PR TITLE
Add commas to price formatting for G-Cloud services

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.25.0'
+__version__ = '7.26.0'

--- a/dmcontent/formats.py
+++ b/dmcontent/formats.py
@@ -13,13 +13,13 @@ def comma_format(number: Union[str, float, int]) -> str:
     :param number: The number to be formatted. Either an int, a float or a str.
     :return: A string of the comma formatted number
     """
-    if type(number) == str:
+    if isinstance(number, str):
         try:
             number = int(number)
         except ValueError:
             number = float(number)
 
-    if type(number) == int:
+    if isinstance(number, int):
         # Don't need to add decimal places to an int
         return f"{number:,}"
     else:

--- a/dmcontent/formats.py
+++ b/dmcontent/formats.py
@@ -2,16 +2,40 @@
 from typing import Optional, Union
 
 
+def comma_format(number: Union[str, float, int]) -> str:
+    """
+    Format a number with commas if it's greater than 999.
+    eg: `1000 -> '1,000'
+        123456.78 -> '123,456.78'
+        '1000000' -> '1,000,000'
+        500 -> '500'
+
+    :param number: The number to be formatted. Either an int, a float or a str.
+    :return: A string of the comma formatted number
+    """
+    if type(number) == str:
+        try:
+            number = int(number)
+        except ValueError:
+            number = float(number)
+
+    if type(number) == int:
+        # Don't need to add decimal places to an int
+        return f"{number:,}"
+    else:
+        return f"{number:,.2f}"
+
+
 def format_price(min_price: Optional[Union[str, float]],
                  max_price: Optional[Union[str, float]],
                  unit: Optional[str],
                  interval: Optional[str],
                  hours_for_price: Optional[str] = None):
     """Format a price string"""
-    if min_price is not None:
-        min_price = str(min_price)
-    if max_price is not None:
-        max_price = str(max_price)
+    if min_price is not None and min_price != '':
+        min_price = comma_format(min_price)
+    if max_price is not None and max_price != '':
+        max_price = comma_format(max_price)
 
     if not (min_price or max_price):
         raise TypeError('One of min_price or max_price should be number or non-empty string, not None')

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from dmcontent.formats import format_price, format_service_price
+from dmcontent.formats import format_price, format_service_price, comma_format
 import pytest
 
 
@@ -47,3 +47,15 @@ def test_format_service_price(price_min, formatted_price):
     }
 
     assert format_service_price(service) == formatted_price
+
+
+@pytest.mark.parametrize('number, formatted_number', [
+    (1000, '1,000'),
+    (123456.78, '123,456.78'),
+    ('1000000', '1,000,000'),
+    (500, '500'),
+    (0.12, '0.12'),
+    (999.99, '999.99'),
+])
+def test_comma_format(number, formatted_number):
+    assert comma_format(number) == formatted_number


### PR DESCRIPTION
Add commas to the prices for G-cloud services so they're easier to read, and bump the minor version number

Addresses https://trello.com/c/UL5WzBD7/1412-add-commas-to-price-formatting-on-g-cloud-service-pages