### PR TITLE
Choose whether to use 'a' or 'an'

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.26.1'
+__version__ = '7.26.2'

--- a/dmcontent/formats.py
+++ b/dmcontent/formats.py
@@ -26,6 +26,20 @@ def comma_format(number: Union[str, float, int]) -> str:
         return f"{number:,.2f}"
 
 
+def _with_a(name: str) -> str:
+    """
+    Try to work out whether to use 'a' or 'an'. The rule is that we should use 'an' where the word starts with a vowel
+    sound. This is not the same as starting with a vowel (e.g. 'an hour', 'a unit'). Apply a heuristic that should work
+    most of the time, with a special case for an obvious edge-case.
+
+    If this is not enough, we shouldn't try to make this heuristic work better - english is hard. Instead, we should use
+    https://github.com/jaraco/inflect and rely on people who've already done the hard work to make it simple.
+    """
+    if name.startswith(("a", "e", "i", "o", "hour")):
+        return f" an {name}"
+    return f" a {name}"
+
+
 def format_price(min_price: Optional[Union[str, float]],
                  max_price: Optional[Union[str, float]],
                  unit: Optional[str],
@@ -51,9 +65,9 @@ def format_price(min_price: Optional[Union[str, float]],
     if max_price:
         formatted_price += u'£{}'.format(max_price)
     if unit:
-        formatted_price += ' a ' + unit.lower()
+        formatted_price += _with_a(unit.lower())
     if interval:
-        formatted_price += ' a ' + interval.lower()
+        formatted_price += _with_a(interval.lower())
     return formatted_price
 
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -5,9 +5,11 @@ import pytest
 
 @pytest.mark.parametrize('args, formatted_price', [
     ((u'12', None, 'Unit', None), u'£12 a unit'),
+    ((u'12', None, 'Hour', None), u'£12 an hour'),
     (('12', '13', 'Unit', None), u'£12 to £13 a unit'),
     (('12', '13', 'Unit', 'Second'), u'£12 to £13 a unit a second'),
     (('12', None, 'Unit', 'Second'), u'£12 a unit a second'),
+    (('12', None, 'Instance', 'Hour'), u'£12 an instance an hour'),
     ((12, 13, 'Unit', None), u'£12 to £13 a unit'),
     (('34', None, 'Lab', None, '4 hours'), u'4 hours for £34'),
     (('12', None, None, None), u'£12'),


### PR DESCRIPTION
Trello: https://trello.com/c/RlNy5WlG/2074-ccsrequests-re-listing-correction

Previously, we always used 'a'. This doesn't work for things like 'a instance', and a supplier has noticed this. Fixing this properly will be a bit involved. So add a heuristic that should work most of the time.

If this is not enough, we should just use inflect rather than trying to write code that understands english better than this.

This is hacky as all heck, so I've included a comment to try and explain this monstrosity to future devs.