### PR TITLE
Add boolean to govuk_frontend

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.26.2'
+__version__ = '7.27.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -101,6 +101,12 @@ def from_question(
             "macro_name": "govukCheckboxes",
             "params": govuk_checkboxes(question, data, errors, **kwargs)
         }
+    elif question.type == "boolean":
+        return {
+            "fieldset": govuk_fieldset(question, **kwargs),
+            "macro_name": "govukRadios",
+            "params": govuk_radios(question, data, errors, **kwargs)
+        }
     elif question.type == "textbox_large":
         return {
             "label": govuk_label(question, **kwargs),
@@ -203,6 +209,12 @@ def govuk_radios(
     # govukRadios wants idPrefix, not id
     del params["id"]
     params["idPrefix"] = f"input-{question.id}"
+
+    if question.get("type") == "boolean":
+        if params.get("classes"):
+            params["classes"] += " govuk-radios--inline"
+        else:
+            params["classes"] = "govuk-radios--inline"
 
     params["items"] = govuk_options(question.options, data.get(question.id))
 
@@ -341,7 +353,7 @@ def get_href(question: 'Question', **kwargs) -> str:
     if govuk_frontend_version[0] >= 3:
         return href
 
-    if question_type in ("checkboxes", "list", "radios"):
+    if question_type in ("checkboxes", "list", "radios", "boolean"):
         href = f"{href}-1"
 
     return href

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -271,6 +271,30 @@ class TestRadios:
         assert form == snapshot
 
 
+class TestBoolean:
+    @pytest.fixture
+    def question(self):
+        return Question(
+            {
+                "id": "yesOrNo",
+                "name": "Yes or no",
+                "question": "Yes or no?",
+                "type": "boolean",
+                "options": [
+                    {"label": "Yes", "value": "yes"},
+                    {"label": "No", "value": "no"},
+                ],
+            }
+        )
+
+    def test_govuk_radios_with_type_boolean(self, question, snapshot):
+        params = govuk_radios(question)
+
+        assert "id" not in params
+        assert params["idPrefix"] == "input-yesOrNo"
+        assert params["classes"] == "govuk-radios--inline"
+
+
 class TestCheckboxes:
     @pytest.fixture
     def question(self):


### PR DESCRIPTION
https://trello.com/c/13tOvxuu/285-2-replace-content-loader-form-macros-in-brief-responses-frontend

digitalmarketplace-frontend-toolkit uses `boolean` questions, which are yes/no inline radio inputs:

![Screenshot 2020-12-03 at 17 44 48](https://user-images.githubusercontent.com/22524634/101067275-43431f80-358f-11eb-8225-4d1b19fbcc9c.png)

We don't currently handle them with govuk_frontend, but our work on `brief-responses` has uncovered some:
`yesNo`
`essentialRequirementsMet`

We can simply use `govukRadios` and add `govuk-radios--inline` to the `classes` property to achieve the effect in govuk-frontend.