### PR TITLE
Add options to boolean question

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.27.0'
+__version__ = '7.27.1'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -215,8 +215,10 @@ def govuk_radios(
             params["classes"] += " govuk-radios--inline"
         else:
             params["classes"] = "govuk-radios--inline"
-
-    params["items"] = govuk_options(question.options, data.get(question.id))
+        options = [{"label": "Yes", "value": "True"}, {"label": "No", "value": "False"}]
+        params["items"] = govuk_options(options, str(data.get(question.id)))
+    else:
+        params["items"] = govuk_options(question.options, data.get(question.id))
 
     return params
 

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -279,11 +279,7 @@ class TestBoolean:
                 "id": "yesOrNo",
                 "name": "Yes or no",
                 "question": "Yes or no?",
-                "type": "boolean",
-                "options": [
-                    {"label": "Yes", "value": "yes"},
-                    {"label": "No", "value": "no"},
-                ],
+                "type": "boolean"
             }
         )
 
@@ -293,6 +289,12 @@ class TestBoolean:
         assert "id" not in params
         assert params["idPrefix"] == "input-yesOrNo"
         assert params["classes"] == "govuk-radios--inline"
+
+    def test_boolean_options_are_yes_and_no(self, question):
+        assert govuk_radios(question)["items"] == [
+            {"value": "True", "text": "Yes"},
+            {"value": "False", "text": "No"},
+        ]
 
 
 class TestCheckboxes:


### PR DESCRIPTION
https://trello.com/c/13tOvxuu/285-2-replace-content-loader-form-macros-in-brief-responses-frontend

During testing on Brief Responses, I discovered that boolean questions don't have an `options` property, and so fail.

This fixes that by setting the options property.