### PR TITLE
Allow date questions to unformat when there is no data

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.27.1'
+__version__ = '7.27.2'

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -631,7 +631,7 @@ class Date(Question):
 
     def unformat_data(self, data):
         result = {}
-        value = data[self.id]
+        value = data.get(self.id, None)
         if value:
             for partial_value, field in zip(value.split('-'), self.FIELDS):
                 result['-'.join([self.id, field])] = partial_value

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -266,6 +266,9 @@ class TestDates(QuestionTest):
             'example-year': '2017',
         }
 
+    def test_unformat_data_with_no_data_returns_empty(self):
+        assert self.question().unformat_data({}) == {}
+
     @pytest.mark.parametrize(
         ("value", "expected"),
         (("11", "11"), ('a', 'a'), ('a ', 'a'), ('01', '01'), (' 0', '0'), ('--', ''), ('-1', ''), ('', ''), (None, ''))

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -154,6 +154,9 @@ class QuestionTest(object):
         if question.type in ("checkboxes", "list", "radios"):
             assert not href.endswith("-1")
 
+    def test_unformat_data_with_no_data_returns_empty(self):
+        assert all(v is None for v in self.question().unformat_data({}).values())
+
 
 class TestText(QuestionTest):
     def question(self, **kwargs):
@@ -265,9 +268,6 @@ class TestDates(QuestionTest):
             'example-month': 'bb',
             'example-year': '2017',
         }
-
-    def test_unformat_data_with_no_data_returns_empty(self):
-        assert self.question().unformat_data({}) == {}
 
     @pytest.mark.parametrize(
         ("value", "expected"),


### PR DESCRIPTION
Is DOS5 the first question when submitting a brief response is a date question, so the brief response has no data at that point. 

Also move unformat test with no data to base class so we know all subclasses of `Question` can handle the case with no data.