### PR TITLE
Add `govuk_frontend.render_question()` for calling govuk-frontend macros from Python

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,4 @@ max-complexity = 12
 max-line-length = 120
 per-file-ignores =
     **/__init__.py : F401
+    dmcontent/govuk_frontend.py: C901

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.27.3'
+__version__ = '7.28.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -451,7 +451,7 @@ def _params(
 # `from_question()` we can safely change the objects emitted by `from_question()`
 # and experiment a bit more.
 
-@jinja2.contextfunction  # noqa: C901
+@jinja2.contextfunction
 def render(ctx, obj, *, question=None) -> Markup:
     """Call Jinja2 macros using Python objects
 

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -1,5 +1,10 @@
 import pytest
 
+from unittest import mock
+
+import jinja2
+from jinja2 import Markup
+
 from dmcontent.questions import Pricing, Question
 
 from dmcontent.govuk_frontend import (
@@ -14,6 +19,7 @@ from dmcontent.govuk_frontend import (
     govuk_fieldset,
     govuk_label,
     _params,
+    render,
 )
 
 
@@ -849,3 +855,93 @@ class TestParams:
         params = _params(question, data, errors)
         assert params["value"] == "Definitely"
         assert params["errorMessage"]["text"] == "Answer yes or no only."
+
+
+class TestRender:
+    @pytest.fixture
+    def context(self):
+        return mock.Mock()
+
+    @pytest.fixture
+    def env(self):
+        env = jinja2.Environment(lstrip_blocks=True, trim_blocks=True)
+        env.globals["render"] = render
+        return env
+
+    def test_it_returns_markup(self, context):
+        assert isinstance(render(context, []), Markup)
+        assert isinstance(render(context, ""), Markup)
+        assert isinstance(render(context, "Hello World"), Markup)
+        assert isinstance(render(context, Markup("<p>Hello World</p>")), Markup)
+
+    def test_it_returns_the_empty_string_if_called_with_nothing(self, context):
+        assert render(context, []) == ""
+        assert render(context, "") == ""
+
+    def test_it_escapes_strings(self, context):
+        assert render(context, "<p>Hello World</p>") == "&lt;p&gt;Hello World&lt;/p&gt;"
+
+    def test_it_does_not_escape_markup(self, context):
+        assert render(context, Markup("<p>Hello World</p>")) == "<p>Hello World</p>"
+
+    def test_it_joins_lists_of_strings(self, context):
+        assert render(context, [Markup("<p>"), "Hello World", Markup("</p>")]) \
+            == Markup("<p>Hello World</p>")
+
+    def test_it_is_passed_context_automatically_when_called_in_jinja_template(self, env):
+        assert env.from_string(
+            "{{ render([]) }}"
+        ).render() == ""
+
+    def test_it_calls_jinja_macros(self, env):
+        template = env.from_string("""{% macro test() -%}
+foo
+{%- endmacro %}
+{{ render([{'macro_name': 'test'}]) }}""")
+        assert template.render() == "foo"
+
+    def test_it_calls_macros_with_params(self, env):
+        test_macro = mock.Mock(return_value="bar")
+        template = env.from_string(
+            "{{ render([{'macro_name': 'test', 'params': {'a': 1, 'b': 2}}]) }}"
+        )
+        assert template.render(test=test_macro) == "bar"
+        assert test_macro.called_with({"a": 1, "b": 2})
+
+    def test_jinja_macros_are_not_escaped(self, env):
+        template = env.from_string("""{% macro test() -%}
+<p>foo</p>
+{%- endmacro %}
+{{ render([{'macro_name': 'test'}]) }}""")
+        assert template.render() == "<p>foo</p>"
+
+        template = env.from_string("""{% macro test(params) -%}
+<p>foo</p>
+{%- endmacro %}
+{{ render([{'macro_name': 'test', 'params': {'bar': 'baz'}}]) }}""")
+        assert template.render() == "<p>foo</p>"
+
+    def test_it_can_wrap_jinja_macros_in_fieldset(self, env):
+        template = env.from_string("""{% macro test() -%}
+bar
+{%- endmacro %}
+{% macro govukFieldset(params) -%}
+<fieldset>{{ caller() }}</fieldset>
+{%- endmacro %}
+{{ render([{'macro_name': 'test', 'fieldset': None}]) }}""")
+
+        assert template.render() == "<fieldset>bar</fieldset>"
+
+    def test_it_calls_fieldset_with_params(self, env):
+        test_macro = mock.Mock(return_value="foo")
+        test_govuk_fieldset = mock.Mock(
+            side_effect=lambda params, caller: params["fizz"]
+        )
+        template = env.from_string(
+            "{{ render([{'macro_name': 'test', 'fieldset': {'fizz': 'buzz'}}]) }}"
+        )
+        assert template.render(test=test_macro, govukFieldset=test_govuk_fieldset) \
+            == "buzz"
+        assert test_govuk_fieldset.call_args_list == [
+            mock.call({"fizz": "buzz"}, caller=mock.ANY)
+        ]


### PR DESCRIPTION
Ticket: https://trello.com/c/fu3k1QO7/290-3-replace-content-loader-questions-with-followup-in-brief-responses-frontend

`render()` is a Python replacement for the [`show_question.html`][1] template that has developed to handle the output of `from_question()`.  While `show_question.html` is working for most cases, it has a couple of downsides

1. we have it repeated across all frontend repos where it's needed
2. it can't handle complex forms such as radios with conditionals
3. it's code is a little bit repetitive

This commit aims to address those problems by moving the logic to show a question into `dmcontent` where it can be shared across all apps, and by rewriting it in Python that should also make it possible to do more complicated things in future.

Currently `render()` is a bit more complicated than it needs to be, so that the output of `from_question()` can stay the same, but in future we can push more of the layout stuff into `from_question()` and make `render()` simpler and more general.

Apps should aim to use the convenience function `render_question()` which calls `from_question()` and `render()` in tandem, so that they don't need to worry about the interface between the two. Add it to your Jinja2 environment globals!

[1]: https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/blob/master/app/templates/macros/show_question.html

---

https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/260 shows this in action.