### PR TITLE
Fix behaviour of render_question with unrecognised question type

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.28.0'
+__version__ = '7.28.1'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -540,8 +540,11 @@ def render_question(
     Convenience function that calls `render()` on the output of
     `from_question()`. In most circumstances this should be all you need.
     """
+    to_render = from_question(question, data, errors, **kwargs)
+    if to_render is None:
+        raise jinja2.UndefinedError(f"unable to render question of type '{question.type}'")
     return render(
         ctx,
-        from_question(question, data, errors, **kwargs),
+        to_render,
         question=question
     )

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -1007,6 +1007,21 @@ class TestRenderQuestion:
                     question=question
                 )
 
+    def test_it_raises_jinja2_undefined_error_if_question_type_is_not_handled(self):
+        ctx = mock.Mock()
+
+        question = Question(
+            {
+                "id": "q1",
+                "name": "Mysterious question",
+                "question": "A question we don't know how to render",
+                "type": "unhandled",
+            }
+        )
+
+        with pytest.raises(jinja2.UndefinedError):
+            render_question(ctx, question)
+
     def test_it_renders_question_advice(self):
         ctx = mock.Mock()
         ctx.resolve.return_value = str


### PR DESCRIPTION
Fixes a bug I found while trying to bump dmcontent in alphagov/digitalmarketplace-briefs-frontend#379.