### PR TITLE
Add support for multiquestion to dmcontent.govuk_frontend

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.28.1'
+__version__ = '7.29.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -470,6 +470,8 @@ def render(ctx, obj, *, question=None) -> Markup:
 
     `render()` always returns `Markup` (i.e. unescaped HTML), so it should be
     used with caution. Do not use it on user input!!
+
+    :type obj: list[dict or str or Markup] or dict or str or Markup
     """
     if isinstance(obj, list):
         return Markup("".join(render(ctx, el) for el in obj))

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -313,7 +313,7 @@ def dm_multiquestion(
     to_render = []
 
     if question.get("question_advice"):
-        to_render.append(question.question_advice)
+        to_render.append(_question_advice(question))
 
     to_render += [
         from_question(q, data, errors, is_page_heading=False)
@@ -461,6 +461,17 @@ def _params(
         params["errorMessage"] = govuk_error(errors[input_id])["errorMessage"]
 
     return params
+
+
+def _question_advice(
+    question: 'Question', **kwargs
+) -> Markup:
+    """Render `question_advice` for `question`"""
+    return (
+        Markup('<span class="dm-question-advice">\n')
+        + question.question_advice
+        + Markup('\n</span>')
+    )
 
 
 # TODO: The code in `render()` is more complicated than it needs to be because

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -135,6 +135,8 @@ def from_question(
             "macro_name": "govukCharacterCount",
             "params": govuk_character_count(question, data, errors, **kwargs)
         }
+    elif question.type == "multiquestion":
+        return dm_multiquestion(question, data, errors, **kwargs)
     else:
         return None
 
@@ -303,6 +305,22 @@ def dm_pricing_input(
     # branch ldeb-spike-pricing-input-multiple-fields for a sketch of how to do
     # the multiple field case.
     raise NotImplementedError("cannot yet handle pricing question with multiple fields")
+
+
+def dm_multiquestion(
+    question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+) -> list:
+    to_render = []
+
+    if question.get("question_advice"):
+        to_render.append(question.question_advice)
+
+    to_render += [
+        from_question(q, data, errors, is_page_heading=False)
+        for q in question.questions
+    ]
+
+    return to_render
 
 
 def govuk_label(question: 'Question', *, is_page_heading: bool = True, **kwargs) -> dict:

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -345,7 +345,11 @@
 ---
 # name: TestDmMultiquestion.test_from_question
   <class 'list'> [
-    'This is some question advice',
+  '
+      <span class="dm-question-advice">
+      This is some question advice
+      </span>
+    ',
     <class 'dict'> {
       'label': <class 'dict'> {
         'for': 'input-question',
@@ -382,7 +386,11 @@
 ---
 # name: TestDmMultiquestion.test_from_question_with_data
   <class 'list'> [
-    'This is some question advice',
+  '
+      <span class="dm-question-advice">
+      This is some question advice
+      </span>
+    ',
     <class 'dict'> {
       'label': <class 'dict'> {
         'for': 'input-question',
@@ -421,7 +429,11 @@
 ---
 # name: TestDmMultiquestion.test_from_question_with_errors
   <class 'list'> [
-    'This is some question advice',
+  '
+      <span class="dm-question-advice">
+      This is some question advice
+      </span>
+    ',
     <class 'dict'> {
       'label': <class 'dict'> {
         'for': 'input-question',
@@ -464,7 +476,11 @@
 ---
 # name: TestDmMultiquestion.test_multiquestion
   <class 'list'> [
-    'This is some question advice',
+  '
+      <span class="dm-question-advice">
+      This is some question advice
+      </span>
+    ',
     <class 'dict'> {
       'label': <class 'dict'> {
         'for': 'input-question',

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -343,6 +343,162 @@
     },
   }
 ---
+# name: TestDmMultiquestion.test_from_question
+  <class 'list'> [
+    'This is some question advice',
+    <class 'dict'> {
+      'label': <class 'dict'> {
+        'for': 'input-question',
+        'text': 'Write the question',
+      },
+      'macro_name': 'govukCharacterCount',
+      'params': <class 'dict'> {
+        'hint': <class 'dict'> {
+          'text': 'Enter at least one word, and no more than 100',
+        },
+        'id': 'input-question',
+        'maxwords': 100,
+        'name': 'question',
+        'spellcheck': True,
+      },
+    },
+    <class 'dict'> {
+      'label': <class 'dict'> {
+        'for': 'input-answer',
+        'text': 'Write the answer',
+      },
+      'macro_name': 'govukCharacterCount',
+      'params': <class 'dict'> {
+        'hint': <class 'dict'> {
+          'text': 'Enter at least one word, and no more than 100',
+        },
+        'id': 'input-answer',
+        'maxwords': 100,
+        'name': 'answer',
+        'spellcheck': True,
+      },
+    },
+  ]
+---
+# name: TestDmMultiquestion.test_from_question_with_data
+  <class 'list'> [
+    'This is some question advice',
+    <class 'dict'> {
+      'label': <class 'dict'> {
+        'for': 'input-question',
+        'text': 'Write the question',
+      },
+      'macro_name': 'govukCharacterCount',
+      'params': <class 'dict'> {
+        'hint': <class 'dict'> {
+          'text': 'Enter at least one word, and no more than 100',
+        },
+        'id': 'input-question',
+        'maxwords': 100,
+        'name': 'question',
+        'spellcheck': True,
+        'value': 'What is going on?',
+      },
+    },
+    <class 'dict'> {
+      'label': <class 'dict'> {
+        'for': 'input-answer',
+        'text': 'Write the answer',
+      },
+      'macro_name': 'govukCharacterCount',
+      'params': <class 'dict'> {
+        'hint': <class 'dict'> {
+          'text': 'Enter at least one word, and no more than 100',
+        },
+        'id': 'input-answer',
+        'maxwords': 100,
+        'name': 'answer',
+        'spellcheck': True,
+        'value': "I don't know.",
+      },
+    },
+  ]
+---
+# name: TestDmMultiquestion.test_from_question_with_errors
+  <class 'list'> [
+    'This is some question advice',
+    <class 'dict'> {
+      'label': <class 'dict'> {
+        'for': 'input-question',
+        'text': 'Write the question',
+      },
+      'macro_name': 'govukCharacterCount',
+      'params': <class 'dict'> {
+        'errorMessage': <class 'dict'> {
+          'text': 'Enter a question.',
+        },
+        'hint': <class 'dict'> {
+          'text': 'Enter at least one word, and no more than 100',
+        },
+        'id': 'input-question',
+        'maxwords': 100,
+        'name': 'question',
+        'spellcheck': True,
+      },
+    },
+    <class 'dict'> {
+      'label': <class 'dict'> {
+        'for': 'input-answer',
+        'text': 'Write the answer',
+      },
+      'macro_name': 'govukCharacterCount',
+      'params': <class 'dict'> {
+        'errorMessage': <class 'dict'> {
+          'text': 'Enter an answer.',
+        },
+        'hint': <class 'dict'> {
+          'text': 'Enter at least one word, and no more than 100',
+        },
+        'id': 'input-answer',
+        'maxwords': 100,
+        'name': 'answer',
+        'spellcheck': True,
+      },
+    },
+  ]
+---
+# name: TestDmMultiquestion.test_multiquestion
+  <class 'list'> [
+    'This is some question advice',
+    <class 'dict'> {
+      'label': <class 'dict'> {
+        'for': 'input-question',
+        'text': 'Write the question',
+      },
+      'macro_name': 'govukCharacterCount',
+      'params': <class 'dict'> {
+        'hint': <class 'dict'> {
+          'text': 'Enter at least one word, and no more than 100',
+        },
+        'id': 'input-question',
+        'maxwords': 100,
+        'name': 'question',
+        'spellcheck': True,
+      },
+    },
+    <class 'dict'> {
+      'label': <class 'dict'> {
+        'for': 'input-answer',
+        'text': 'Write the answer',
+      },
+      'macro_name': 'govukCharacterCount',
+      'params': <class 'dict'> {
+        'hint': <class 'dict'> {
+          'text': 'Enter at least one word, and no more than 100',
+        },
+        'id': 'input-answer',
+        'maxwords': 100,
+        'name': 'answer',
+        'spellcheck': True,
+      },
+    },
+  ]
+---
 # name: TestDmPricingInput.test_dm_pricing_input_with_price_field
   <class 'dict'> {
     'label': <class 'dict'> {

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -685,7 +685,9 @@ class TestDmMultiquestion:
             ]
 
     def test_dm_multiquestion_shows_question_advice(self, question):
+        question_advice_html = dm_multiquestion(question)[0]
         assert question.question_advice in dm_multiquestion(question)[0]
+        assert isinstance(question_advice_html, Markup)
 
     def test_dm_multiquestion_shows_questions(self, question):
         result = dm_multiquestion(question)

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -5,7 +5,7 @@ from unittest import mock
 import jinja2
 from jinja2 import Markup
 
-from dmcontent.questions import Pricing, Question
+from dmcontent.questions import Pricing, Question, Multiquestion
 
 from dmcontent.govuk_frontend import (
     from_question,
@@ -16,6 +16,7 @@ from dmcontent.govuk_frontend import (
     govuk_radios,
     dm_list_input,
     dm_pricing_input,
+    dm_multiquestion,
     govuk_fieldset,
     govuk_label,
     _params,
@@ -620,6 +621,125 @@ class TestDmPricingInput:
                 assert "--error" in component["params"]["classes"]
         else:
             raise ValueError("form should have params or a fieldset")
+
+        assert form == snapshot
+
+
+class TestDmMultiquestion:
+    @pytest.fixture
+    def question(self):
+        return Multiquestion(
+            {
+                "id": "questionAndAnswer",
+                "name": "questionAndAnswer",
+                "type": "multiquestion",
+                "question": "This is a Multiquestion",
+                "question_advice": "This is some question advice",
+                "questions": [
+                    {
+                        "id": "question",
+                        "name": "Question",
+                        "question": "Write the question",
+                        "type": "textbox_large",
+                        "hint": "Enter at least one word, and no more than 100",
+                        "max_length_in_words": 100,
+                    },
+                    {
+                        "id": "answer",
+                        "name": "Answer",
+                        "question": "Write the answer",
+                        "type": "textbox_large",
+                        "hint": "Enter at least one word, and no more than 100",
+                        "max_length_in_words": 100,
+                    }
+                ]
+            }
+        )
+
+    def test_multiquestion(self, question, snapshot):
+        assert dm_multiquestion(question) == snapshot
+
+    def test_dm_multiquestion_returns_a_list_of_renderables(self, question):
+        """Test that the ouput of dm_multiquestion can be handled by render()"""
+        assert isinstance(dm_multiquestion(question), list)
+        for sub_question in dm_multiquestion(question):
+            assert isinstance(sub_question, (dict, Markup, str))
+
+    def test_dm_multiquestion_calls_from_question_on_each_of_its_questions(self, question):
+        with mock.patch("dmcontent.govuk_frontend.from_question") as from_question:
+            dm_multiquestion(question)
+            assert from_question.call_count == len(question.questions)
+            assert from_question.call_args_list == [
+                mock.call(sub_question, None, None, is_page_heading=False)
+                for sub_question in question.questions
+            ]
+
+    def test_dm_multiquestion_passes_data_and_errors_for_each_of_its_questions(self, question):
+        with mock.patch("dmcontent.govuk_frontend.from_question") as from_question:
+            data = mock.MagicMock()
+            errors = mock.MagicMock()
+            dm_multiquestion(question, data, errors)
+            assert from_question.call_args_list == [
+                mock.call(sub_question, data, errors, is_page_heading=False)
+                for sub_question in question.questions
+            ]
+
+    def test_dm_multiquestion_shows_question_advice(self, question):
+        assert question.question_advice in dm_multiquestion(question)[0]
+
+    def test_dm_multiquestion_shows_questions(self, question):
+        result = dm_multiquestion(question)
+
+        assert result[1]["label"]["text"] == "Write the question"
+        assert result[1]["macro_name"] == "govukCharacterCount"
+        assert result[1]["params"]["id"] == "input-question"
+
+        assert result[2]["label"]["text"] == "Write the answer"
+        assert result[2]["macro_name"] == "govukCharacterCount"
+        assert result[2]["params"]["id"] == "input-answer"
+
+    def test_dm_multiquestion_question_labels_are_not_page_headings(self, question):
+        output = dm_multiquestion(question)
+
+        for q in output[1:]:
+            assert not q["label"].get("isPageHeading")
+
+    def test_from_question(self, question, snapshot):
+        assert from_question(question) == snapshot
+
+    def test_from_question_with_data(self, question, snapshot):
+        data = {
+            "question": "What is going on?",
+            "answer": "I don't know.",
+        }
+
+        form = from_question(question, data)
+
+        assert form[1]["params"]["value"] == "What is going on?"
+        assert form[2]["params"]["value"] == "I don't know."
+
+        assert form == snapshot
+
+    def test_from_question_with_errors(self, question, snapshot):
+        errors = {
+            "question": {
+                "input_name": "question",
+                "href": "#input-question",
+                "question": "What's the question?",
+                "message": "Enter a question.",
+            },
+            "answer": {
+                "input_name": "answer",
+                "href": "#input-answer",
+                "question": "What's the answer?",
+                "message": "Enter an answer.",
+            },
+        }
+
+        form = from_question(question, errors=errors)
+
+        assert form[1]["params"]["errorMessage"]
+        assert form[2]["params"]["errorMessage"]
 
         assert form == snapshot
 


### PR DESCRIPTION
Ticket: https://trello.com/c/YG2SH78x/751-3-add-support-for-multiquestions-to-dmcontentgovukfrontend

We want to be able to render multiquestions using `govuk_frontend.render_question()`. This PR adds support for simple multiquestions (no followup/conditionally revealed content).

https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/383 shows an example of this in an app.