### PR TITLE
Add support for followup questions in multiquestions

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.29.0'
+__version__ = '7.30.0'

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -474,6 +474,164 @@
     },
   ]
 ---
+# name: TestDmMultiquestion.test_from_question_with_followup
+  <class 'list'> [
+  '
+      <span class="dm-question-advice">
+      This is some question advice
+      </span>
+    ',
+    <class 'dict'> {
+      'fieldset': <class 'dict'> {
+        'legend': <class 'dict'> {
+          'classes': 'govuk-fieldset__legend--m',
+          'text': 'Yes or no?',
+        },
+      },
+      'macro_name': 'govukRadios',
+      'params': <class 'dict'> {
+        'classes': 'govuk-radios--inline',
+        'idPrefix': 'input-yesNo',
+        'items': <class 'list'> [
+          <class 'dict'> {
+            'conditional': <class 'dict'> {
+              'html': <class 'dict'> {
+                'label': <class 'dict'> {
+                  'for': 'input-tellUsMore',
+                  'text': 'Tell us more',
+                },
+                'macro_name': 'govukCharacterCount',
+                'params': <class 'dict'> {
+                  'hint': <class 'dict'> {
+                    'text': 'Enter at least one word, and no more than 100',
+                  },
+                  'id': 'input-tellUsMore',
+                  'maxwords': 100,
+                  'name': 'tellUsMore',
+                  'spellcheck': True,
+                },
+              },
+            },
+            'text': 'Yes',
+            'value': 'True',
+          },
+          <class 'dict'> {
+            'text': 'No',
+            'value': 'False',
+          },
+        ],
+        'name': 'yesNo',
+      },
+    },
+  ]
+---
+# name: TestDmMultiquestion.test_from_question_with_followup_with_data
+  <class 'list'> [
+  '
+      <span class="dm-question-advice">
+      This is some question advice
+      </span>
+    ',
+    <class 'dict'> {
+      'fieldset': <class 'dict'> {
+        'legend': <class 'dict'> {
+          'classes': 'govuk-fieldset__legend--m',
+          'text': 'Yes or no?',
+        },
+      },
+      'macro_name': 'govukRadios',
+      'params': <class 'dict'> {
+        'classes': 'govuk-radios--inline',
+        'idPrefix': 'input-yesNo',
+        'items': <class 'list'> [
+          <class 'dict'> {
+            'checked': True,
+            'conditional': <class 'dict'> {
+              'html': <class 'dict'> {
+                'label': <class 'dict'> {
+                  'for': 'input-tellUsMore',
+                  'text': 'Tell us more',
+                },
+                'macro_name': 'govukCharacterCount',
+                'params': <class 'dict'> {
+                  'hint': <class 'dict'> {
+                    'text': 'Enter at least one word, and no more than 100',
+                  },
+                  'id': 'input-tellUsMore',
+                  'maxwords': 100,
+                  'name': 'tellUsMore',
+                  'spellcheck': True,
+                  'value': "Gosh, there's a lot to say.",
+                },
+              },
+            },
+            'text': 'Yes',
+            'value': 'True',
+          },
+          <class 'dict'> {
+            'text': 'No',
+            'value': 'False',
+          },
+        ],
+        'name': 'yesNo',
+      },
+    },
+  ]
+---
+# name: TestDmMultiquestion.test_from_question_with_followup_with_errors
+  <class 'list'> [
+  '
+      <span class="dm-question-advice">
+      This is some question advice
+      </span>
+    ',
+    <class 'dict'> {
+      'fieldset': <class 'dict'> {
+        'legend': <class 'dict'> {
+          'classes': 'govuk-fieldset__legend--m',
+          'text': 'Yes or no?',
+        },
+      },
+      'macro_name': 'govukRadios',
+      'params': <class 'dict'> {
+        'classes': 'govuk-radios--inline',
+        'idPrefix': 'input-yesNo',
+        'items': <class 'list'> [
+          <class 'dict'> {
+            'conditional': <class 'dict'> {
+              'html': <class 'dict'> {
+                'label': <class 'dict'> {
+                  'for': 'input-tellUsMore',
+                  'text': 'Tell us more',
+                },
+                'macro_name': 'govukCharacterCount',
+                'params': <class 'dict'> {
+                  'errorMessage': <class 'dict'> {
+                    'text': 'Enter an answer.',
+                  },
+                  'hint': <class 'dict'> {
+                    'text': 'Enter at least one word, and no more than 100',
+                  },
+                  'id': 'input-tellUsMore',
+                  'maxwords': 100,
+                  'name': 'tellUsMore',
+                  'spellcheck': True,
+                },
+              },
+            },
+            'text': 'Yes',
+            'value': 'True',
+          },
+          <class 'dict'> {
+            'text': 'No',
+            'value': 'False',
+          },
+        ],
+        'name': 'yesNo',
+      },
+    },
+  ]
+---
 # name: TestDmMultiquestion.test_multiquestion
   <class 'list'> [
   '


### PR DESCRIPTION
Ticket: https://trello.com/c/cMtAeSL2/764-3-add-support-for-conditionally-revealed-content-to-dmcontentgovukfronted

We want to be able to handle multiquestions that contain questoins with followups, like DOS5's [niceToHaveRequirements and yesNo questions][1]. The Design System calls this [conditionally revealing content][2].

This PR adds logic to `dm_multiquestion()` to handle these questions.

We put the logic here rather than in say `govukRadios()` because a) the way followups currently work is a little confusing, and b) it would be better in the long term to re-evaluate how we lay out these questions for the user and define them in the framework manifests. For now this commit gives us some form of backwards compatibility to unblock migration to govuk-frontend.

### Visual changes

This does change how these questions will look for users, in a few small ways:

- 'yes' or 'no' selection question will not have inline radios
- followup appears between 'yes' and 'no'
- labels for followup questions are not bold
- the space for followup questions is slightly smaller (this might just be a difference between frontend toolkit textbox and govuk-frontend character count components)

I think these differences are small enough that we shouldn't work around them however.

<table>
<thead>
<td>Before:</td>
<td>After:</td>
</thead>
<trow>
<td>
<img width="624" alt="Screenshot 2021-02-01 at 15 02 56" src="https://user-images.githubusercontent.com/503614/106476093-91e13d00-649e-11eb-9c0c-2cbcf8034b39.png">
</td>
<td>
<img width="673" alt="Screenshot 2021-02-01 at 15 03 14" src="https://user-images.githubusercontent.com/503614/106476124-9e659580-649e-11eb-82dd-fcdbe594e6ed.png">
</td>
</trow>
</table>

[1]: https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/niceToHaveRequirements.yml
[2]: https://design-system.service.gov.uk/components/radios/#conditionally-revealing-content