### PR TITLE
Add type hints to `get_error_messages`

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.30.0'
+__version__ = '7.30.1'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -355,7 +355,7 @@ class ContentSection(object):
             any(form_field not in service for form_field in self.get_field_names())
         ])
 
-    def get_error_messages(self, errors, question_descriptor_from="label"):
+    def get_error_messages(self, errors: dict, question_descriptor_from: str = "label") -> OrderedDict:
         """Convert API error keys into error messages
 
         :param errors: error dictionary as returned by the data API

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -102,7 +102,7 @@ class Question(object):
 
         return {self.id: value}
 
-    def get_error_messages(self, errors, question_descriptor_from="label"):
+    def get_error_messages(self, errors: dict, question_descriptor_from: str = "label") -> dict:
         error_fields = set(errors.keys()) & set(self.form_fields)
         if not error_fields:
             return {}
@@ -305,7 +305,7 @@ class Multiquestion(Question):
     def get_question_ids(self, type=None):
         return [question.id for question in self.questions if type in [question.type, None]]
 
-    def get_error_messages(self, errors, question_descriptor_from="label"):
+    def get_error_messages(self, errors: dict, question_descriptor_from: str = "label") -> OrderedDict:
         # Multi-question errors should have the same ordering as the questions
         errors = super(Multiquestion, self).get_error_messages(
             errors, question_descriptor_from=question_descriptor_from
@@ -439,7 +439,7 @@ class DynamicList(Multiquestion):
 
         return result
 
-    def get_error_messages(self, errors, question_descriptor_from="label"):
+    def get_error_messages(self, errors: dict, question_descriptor_from: str = "label") -> OrderedDict:
         if self.id not in errors:
             return {}
 
@@ -651,7 +651,7 @@ class QuestionSummary(Question):
     def _default_for_field(self, field_key):
         return self.get('field_defaults', {}).get(field_key)
 
-    def get_error_messages(self, errors, question_descriptor_from="label"):
+    def get_error_messages(self, errors: dict, question_descriptor_from: str = "label") -> dict:
 
         question_errors = super(QuestionSummary, self).get_error_messages(
             errors,


### PR DESCRIPTION
https://trello.com/c/9RUq5TL8/1243-2-bug-emessage-passed-to-inappropriate-error-handler

We have previously introduced bugs by passing the wrong type in. Add type hints to make this mistake harder to make in future.