### PR TITLE
Allow lazy loading of manifests 

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.30.1'
+__version__ = '7.31.0'

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -175,3 +175,32 @@ def count_unanswered_questions(service_attributes: "ContentManifest") -> typing.
                 unanswered_optional += 1
 
     return unanswered_required, unanswered_optional
+
+
+class LazyDict(collections.MutableMapping):
+    """
+    A dictionary for values that will be lazily evaluated the first time they are requested.
+    If a value is callable, then it will be called the first time that value is requested and the result cached.
+
+    This is probably not thread safe, so any callable inserted should be idempotent
+    """
+    def __init__(self, *args, **kw):
+        self._raw_dict = dict(*args, **kw)
+
+    def __getitem__(self, key):
+        if key in self._raw_dict and callable(self._raw_dict.get(key)):
+            self._raw_dict[key] = self._raw_dict[key]()
+
+        return self._raw_dict.__getitem__(key)
+
+    def __iter__(self):
+        return iter(self._raw_dict)
+
+    def __len__(self):
+        return len(self._raw_dict)
+
+    def __setitem__(self, key, value):
+        self._raw_dict.__setitem__(key, value)
+
+    def __delitem__(self, value):
+        self._raw_dict.__delitem__(value)

--- a/dmcontent/utils.py
+++ b/dmcontent/utils.py
@@ -202,5 +202,5 @@ class LazyDict(collections.MutableMapping):
     def __setitem__(self, key, value):
         self._raw_dict.__setitem__(key, value)
 
-    def __delitem__(self, value):
-        self._raw_dict.__delitem__(value)
+    def __delitem__(self, key):
+        self._raw_dict.__delitem__(key)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ from dmcontent.utils import (
     try_load_manifest,
     try_load_metadata,
     try_load_messages,
-    count_unanswered_questions,
+    count_unanswered_questions, LazyDict,
 )
 
 
@@ -359,3 +359,33 @@ def test_count_unanswered_questions():
     )
 
     assert count_unanswered_questions(mock_content_manifest) == (6, 3)
+
+
+class TestLazyDict:
+    def setup(self):
+        self.callable_mock = mock.Mock()
+
+    def test_stores_callables(self):
+        LazyDict(test=self.callable_mock)
+
+        assert self.callable_mock.call_count == 0
+
+    def test_calls_lazily(self):
+        test_dict = LazyDict(test=self.callable_mock)
+
+        test_dict.get("test")
+
+        assert self.callable_mock.call_count == 1
+
+    def test_caches_result(self):
+        test_dict = LazyDict(test=self.callable_mock)
+
+        test_dict.get("test")
+        test_dict.get("test")
+
+        assert self.callable_mock.call_count == 1
+
+    def test_stores_non_callables(self):
+        test_dict = LazyDict(test="test")
+
+        assert test_dict.get("test") == "test"


### PR DESCRIPTION
Manifests are slow to load - they take ~1 second each. This contributes to very slow app startup times - ~20-30 seconds for supplier-frontend.

Many of the manifests are for old frameworks that are requested very rarely or not at all. Thus, we can lazily load these old frameworks to give us a speedup on app startup without significantly slowing down real users.

See alphagov/digitalmarketplace-supplier-frontend#1348 for the experimental version of this I used for testing. Based on the numbers in that PR, I think this will save developers a few minutes per day of waiting for tests, which will add up significantly over the course of a year.

Note that the LazyDict created for this purpose is not thread safe. This is not a problem. The worst that could happen is that two threads simultaneously load the manifest. This would result in some wasted work. However, loading a manifest is idempotent, so there would be no other harmful effects.