### PR TITLE
Replace make with invoke

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,3 +10,4 @@ max-line-length = 120
 per-file-ignores =
     **/__init__.py : F401
     dmcontent/govuk_frontend.py: C901
+    tasks.py: F401

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,11 @@ jobs:
           path: venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
 
+      - name: Install developer tools
+        run: make bootstrap
+
       - name: Install dependencies
-        run: make requirements-dev
+        run: invoke requirements-dev
 
       - name: Run tests
-        run: make test
+        run: invoke test

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,21 @@
-SHELL := /bin/bash
-VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
-.PHONY: virtualenv
-virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
+.DEFAULT_GOAL := bootstrap
 
-.PHONY: requirements
-requirements: virtualenv requirements.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
+%:
+	-@[ -z "$$TERM" ] || tput setaf 1  # red
+	@>&2 echo warning: calling '`make`' is being deprecated in this repo, you should use '`invoke` (https://pyinvoke.org)' instead.
+	-@[ -z "$$TERM" ] || tput setaf 9  # default
+	@# pass goals to '`invoke`'
+	invoke $(or $(MAKECMDGOALS), $@)
+	@exit
 
-.PHONY: requirements-dev
-requirements-dev: virtualenv requirements.txt requirements-dev.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt -r requirements-dev.txt
+help:
+	invoke --list
 
-.PHONY: freeze-requirements
-freeze-requirements: virtualenv requirements-dev requirements.in setup.py requirements-dev.in
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements.in
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements-dev.in
-
-.PHONY: test
-test: test-flake8 test-python
-
-.PHONY: test-flake8
-test-flake8: virtualenv
-	${VIRTUALENV_ROOT}/bin/flake8 .
-
-.PHONY: test-python
-test-python: virtualenv
-	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
+.PHONY: bootstrap
+bootstrap:
+	pip install digitalmarketplace-developer-tools
+	@echo done
+	-@[ -z "$$TERM" ] || tput setaf 2  # green
+	@>&2 echo dmdevtools has been installed globally, run developer tasks with '`invoke`'
+	-@[ -z "$$TERM" ] || tput setaf 9  # default

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ Originally was part of [Digital Marketplace Utils](https://github.com/alphagov/d
 Install Python dependencies
 
 ```
-make requirements-dev
+make bootstrap
+invoke requirements-dev
 ```
 
 Run the tests
 
 ```
-make test
+invoke test
 ```
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,1 @@
+from dmdevtools.invoke_tasks import library_tasks as ns


### PR DESCRIPTION
We want to be able to reduce duplication of code across our repos; one
of the places we have a lot of duplicated code is in our Makefiles; all
of our repos have very similar Makefiles with small historical
differences.

This commit replaces Make with invoke, using the tasks from
alphagov/digitalmarketplace-developer-tools.