### PR TITLE
Add support for file upload questions

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.31.0'
+__version__ = '7.32.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -135,6 +135,11 @@ def from_question(
             "macro_name": "govukCharacterCount",
             "params": govuk_character_count(question, data, errors, **kwargs)
         }
+    elif question.type == "upload":
+        return {
+            "macro_name": "govukFileUpload",
+            "params": govuk_file_upload(question, data, errors, **kwargs)
+        }
     elif question.type == "multiquestion":
         return dm_multiquestion(question, data, errors, **kwargs)
     else:
@@ -243,6 +248,36 @@ def govuk_radios(
         params["items"] = govuk_options(options, str(data.get(question.id)))
     else:
         params["items"] = govuk_options(question.options, data.get(question.id))
+
+    return params
+
+
+def govuk_file_upload(
+        question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
+) -> dict:
+    """Create govukFileUpload macro parameters from a file upload question"""
+    params = _params(question, data, errors, **kwargs)
+
+    params["label"] = {"text": question.question}
+
+    params["hint"] = {"html": ""}
+    if question.get("question_advice"):
+        params["hint"]["html"] += question.get("question_advice")
+
+    if question.get("hint"):
+        params["hint"]["html"] += question.get("hint")
+
+    # If the user has previously uploaded a file for this question
+    # add a line to the hint text rather than pre-filling the input
+    if data and data.get(params["name"]):
+        params["hint"]["html"] += Markup("<p>Previously uploaded file:<br>")
+        params["hint"]["html"] += Markup(data.get(params["name"]))
+        params["hint"]["html"] += Markup("</p>")
+
+    # Set an empty key in params for `question_advice` so `render` doesn't
+    # add the advice again.
+    # TODO: remove this once `render` doesn't check for question advice
+    params["question_advice"] = ""
 
     return params
 

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -34,6 +34,7 @@ this function can call (this is not an exhaustive list):
     - govukInput
     - govukLabel
     - govukRadios
+    - govukFileUpload
     - dmListInput
 
 `render_question()` should cover all the usual cases of creating a form from a

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -1046,3 +1046,98 @@
     },
   }
 ---
+# name: TestFileUpload.test_govuk_file_upload
+  <class 'dict'> {
+    'hint': <class 'dict'> {
+      'html': Markup('Your file should meet accessibility standardsRead the guidance on accessible documents (opens in new tab)'),
+    },
+    'id': 'input-file-upload',
+    'label': <class 'dict'> {
+      'text': Markup('Upload a file'),
+    },
+    'name': 'file-upload',
+    'question_advice': '',
+  }
+---
+# name: TestFileUpload.test_govuk_file_upload_with_errors
+  <class 'dict'> {
+    'errorMessage': <class 'dict'> {
+      'text': 'You must select a file to upload.',
+    },
+    'hint': <class 'dict'> {
+      'html': Markup('Your file should meet accessibility standardsRead the guidance on accessible documents (opens in new tab)'),
+    },
+    'id': 'input-file-upload',
+    'label': <class 'dict'> {
+      'text': Markup('Upload a file'),
+    },
+    'name': 'file-upload',
+    'question_advice': '',
+  }
+---
+# name: TestFileUpload.test_govuk_file_upload_with_data
+  <class 'dict'> {
+    'hint': <class 'dict'> {
+      'html': Markup('Your file should meet accessibility standardsRead the guidance on accessible documents (opens in new tab)<p>Previously uploaded file:<br>https://assets.digitalmarketplace.com/path/to/file.pdf</p>'),
+    },
+    'id': 'input-file-upload',
+    'label': <class 'dict'> {
+      'text': Markup('Upload a file'),
+    },
+    'name': 'file-upload',
+    'question_advice': '',
+    'value': 'https://assets.digitalmarketplace.com/path/to/file.pdf',
+  }
+---
+# name: TestFileUpload.test_from_question
+  <class 'dict'> {
+    'macro_name': 'govukFileUpload',
+    'params': <class 'dict'> {
+      'hint': <class 'dict'> {
+        'html': Markup('Your file should meet accessibility standardsRead the guidance on accessible documents (opens in new tab)'),
+      },
+      'id': 'input-file-upload',
+      'label': <class 'dict'> {
+        'text': Markup('Upload a file'),
+      },
+      'name': 'file-upload',
+      'question_advice': '',
+    },
+  }
+---
+# name: TestFileUpload.test_from_question_with_errors
+  <class 'dict'> {
+    'macro_name': 'govukFileUpload',
+    'params': <class 'dict'> {
+      'errorMessage': <class 'dict'> {
+        'text': 'You must select a file to upload.',
+      },
+      'hint': <class 'dict'> {
+        'html': Markup('Your file should meet accessibility standardsRead the guidance on accessible documents (opens in new tab)'),
+      },
+      'id': 'input-file-upload',
+      'label': <class 'dict'> {
+        'text': Markup('Upload a file'),
+      },
+      'name': 'file-upload',
+      'question_advice': '',
+    },
+  }
+---
+# name: TestFileUpload.test_from_question_with_data
+  <class 'dict'> {
+    'macro_name': 'govukFileUpload',
+    'params': <class 'dict'> {
+      'hint': <class 'dict'> {
+        'html': Markup('Your file should meet accessibility standardsRead the guidance on accessible documents (opens in new tab)<p>Previously uploaded file:<br>https://assets.digitalmarketplace.com/path/to/file.pdf</p>'),
+      },
+      'id': 'input-file-upload',
+      'label': <class 'dict'> {
+        'text': Markup('Upload a file'),
+      },
+      'name': 'file-upload',
+      'question_advice': '',
+      'value': 'https://assets.digitalmarketplace.com/path/to/file.pdf',
+    },
+  }
+---

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -14,6 +14,7 @@ from dmcontent.govuk_frontend import (
     govuk_input,
     govuk_checkboxes,
     govuk_radios,
+    govuk_file_upload,
     dm_list_input,
     dm_pricing_input,
     dm_multiquestion,
@@ -447,6 +448,62 @@ class TestDateInput:
         form = from_question(question, errors=errors)
 
         assert "errorMessage" in form["params"]
+        assert form == snapshot
+
+
+class TestFileUpload:
+    @pytest.fixture
+    def question(self):
+        return Question(
+            {
+                "id": "file-upload",
+                "name": Markup("File upload required"),
+                "question": Markup("Upload a file"),
+                "question_advice": Markup("Your file should meet accessibility standards"),
+                "type": "upload",
+                "hint": Markup("Read the guidance on accessible documents (opens in new tab)")
+            }
+        )
+
+    @pytest.fixture
+    def errors(self):
+        return {
+            "file-upload": {
+                "input_name": "file-upload",
+                "href": "#input-file-upload",
+                "question": "Upload a file",
+                "message": "You must select a file to upload.",
+            }
+        }
+
+    @pytest.fixture
+    def data(self):
+        return {
+            "file-upload": "https://assets.digitalmarketplace.com/path/to/file.pdf"
+        }
+
+    def test_govuk_file_upload(self, question, snapshot):
+        params = govuk_file_upload(question)
+        assert params == snapshot
+
+    def test_govuk_file_upload_with_errors(self, question, errors, snapshot):
+        params = govuk_file_upload(question, errors=errors)
+        assert params == snapshot
+
+    def test_govuk_file_upload_with_data(self, question, data, snapshot):
+        params = govuk_file_upload(question, data=data)
+        assert params == snapshot
+
+    def test_from_question(self, question, snapshot):
+        form = from_question(question)
+        assert snapshot == form
+
+    def test_from_question_with_errors(self, question, errors, snapshot):
+        form = from_question(question, errors=errors)
+        assert snapshot == form
+
+    def test_from_question_with_data(self, question, data, snapshot):
+        form = from_question(question, data=data)
         assert form == snapshot
 
 


### PR DESCRIPTION
We want to use the `govukFileUpload` component[[1]] for our questions with `type: upload`[[2]].
Add a branch to `render_question` that generates parameters suitable for this component.

https://trello.com/c/7Hw9pH6X/855-2-add-type-upload-to-content-loader-renderquestion

[1]: https://design-system.service.gov.uk/components/file-upload/
[2]: https://github.com/alphagov/digitalmarketplace-frameworks/blob/a691598f98aa4a21c2615bdc07437898abe1591e/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryStatement.yml