### PR TITLE
Add h3 to markdown.GOVUKFrontendExtension

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.32.0'
+__version__ = '7.33.0'

--- a/dmcontent/markdown.py
+++ b/dmcontent/markdown.py
@@ -35,7 +35,8 @@ class GOVUKFrontendExtension(Extension):
         "ul": "govuk-list govuk-list--bullet",
         "ol": "govuk-list govuk-list--number",
         "a": "govuk-link",
-        "h2": "govuk-heading-m"
+        "h2": "govuk-heading-m",
+        "h3": "govuk-heading-s",
     }
 
     def extendMarkdown(self, md, md_globals):


### PR DESCRIPTION
You now can use markdown h3 syntax in template content.