### PR TITLE
Allow for multiple conditional questions

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.33.0'
+__version__ = '7.34.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -378,9 +378,12 @@ def dm_multiquestion(
 
             for item in items:
                 if item["value"] in followups:
-                    followup_q = question.get_question(followups[item["value"]][0])
+                    followup_items = []
+                    for followup_id in followups[item["value"]]:
+                        followup_q = question.get_question(followup_id)
+                        followup_items.append(from_question(followup_q, data, errors, is_page_heading=False))
                     item["conditional"] = {
-                        "html": from_question(followup_q, data, errors, is_page_heading=False)
+                        "html": followup_items
                     }
 
     return to_render
@@ -589,11 +592,7 @@ def render(ctx, obj, *, question=None) -> Markup:
                 def visit(inner_obj):
                     if isinstance(inner_obj, dict):
                         for k, v in inner_obj.items():
-                            if (
-                                k == "html"
-                                and isinstance(v, dict)
-                                and "macro_name" in v
-                            ):
+                            if k == "html":
                                 inner_obj["html"] = render(ctx, v)
                             else:
                                 visit(v)

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -378,10 +378,10 @@ def dm_multiquestion(
 
             for item in items:
                 if item["value"] in followups:
-                    followup_items = []
-                    for followup_id in followups[item["value"]]:
-                        followup_q = question.get_question(followup_id)
-                        followup_items.append(from_question(followup_q, data, errors, is_page_heading=False))
+                    followup_items = [
+                        from_question(question.get_question(followup_id), data, errors, is_page_heading=False)
+                        for followup_id in followups[item["value"]]
+                    ]
                     item["conditional"] = {
                         "html": followup_items
                     }

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -494,22 +494,24 @@
         'items': <class 'list'> [
           <class 'dict'> {
             'conditional': <class 'dict'> {
-              'html': <class 'dict'> {
-                'label': <class 'dict'> {
-                  'for': 'input-tellUsMore',
-                  'text': 'Tell us more',
-                },
-                'macro_name': 'govukCharacterCount',
-                'params': <class 'dict'> {
-                  'hint': <class 'dict'> {
-                    'text': 'Enter at least one word, and no more than 100',
+              'html': <class 'list'> [
+                <class 'dict'> {
+                  'label': <class 'dict'> {
+                    'for': 'input-tellUsMore',
+                    'text': 'Tell us more',
                   },
-                  'id': 'input-tellUsMore',
-                  'maxwords': 100,
-                  'name': 'tellUsMore',
-                  'spellcheck': True,
+                  'macro_name': 'govukCharacterCount',
+                  'params': <class 'dict'> {
+                    'hint': <class 'dict'> {
+                      'text': 'Enter at least one word, and no more than 100',
+                    },
+                    'id': 'input-tellUsMore',
+                    'maxwords': 100,
+                    'name': 'tellUsMore',
+                    'spellcheck': True,
+                  },
                 },
-              },
+              ],
             },
             'text': 'Yes',
             'value': 'True',
@@ -545,23 +547,25 @@
           <class 'dict'> {
             'checked': True,
             'conditional': <class 'dict'> {
-              'html': <class 'dict'> {
-                'label': <class 'dict'> {
-                  'for': 'input-tellUsMore',
-                  'text': 'Tell us more',
-                },
-                'macro_name': 'govukCharacterCount',
-                'params': <class 'dict'> {
-                  'hint': <class 'dict'> {
-                    'text': 'Enter at least one word, and no more than 100',
+              'html': <class 'list'> [
+                <class 'dict'> {
+                  'label': <class 'dict'> {
+                    'for': 'input-tellUsMore',
+                    'text': 'Tell us more',
                   },
-                  'id': 'input-tellUsMore',
-                  'maxwords': 100,
-                  'name': 'tellUsMore',
-                  'spellcheck': True,
-                  'value': "Gosh, there's a lot to say.",
+                  'macro_name': 'govukCharacterCount',
+                  'params': <class 'dict'> {
+                    'hint': <class 'dict'> {
+                      'text': 'Enter at least one word, and no more than 100',
+                    },
+                    'id': 'input-tellUsMore',
+                    'maxwords': 100,
+                    'name': 'tellUsMore',
+                    'spellcheck': True,
+                    'value': "Gosh, there's a lot to say.",
+                  },
                 },
-              },
+              ],
             },
             'text': 'Yes',
             'value': 'True',
@@ -596,25 +600,237 @@
         'items': <class 'list'> [
           <class 'dict'> {
             'conditional': <class 'dict'> {
-              'html': <class 'dict'> {
-                'label': <class 'dict'> {
-                  'for': 'input-tellUsMore',
-                  'text': 'Tell us more',
-                },
-                'macro_name': 'govukCharacterCount',
-                'params': <class 'dict'> {
-                  'errorMessage': <class 'dict'> {
-                    'text': 'Enter an answer.',
+              'html': <class 'list'> [
+                <class 'dict'> {
+                  'label': <class 'dict'> {
+                    'for': 'input-tellUsMore',
+                    'text': 'Tell us more',
                   },
-                  'hint': <class 'dict'> {
-                    'text': 'Enter at least one word, and no more than 100',
+                  'macro_name': 'govukCharacterCount',
+                  'params': <class 'dict'> {
+                    'errorMessage': <class 'dict'> {
+                      'text': 'Enter an answer.',
+                    },
+                    'hint': <class 'dict'> {
+                      'text': 'Enter at least one word, and no more than 100',
+                    },
+                    'id': 'input-tellUsMore',
+                    'maxwords': 100,
+                    'name': 'tellUsMore',
+                    'spellcheck': True,
                   },
-                  'id': 'input-tellUsMore',
-                  'maxwords': 100,
-                  'name': 'tellUsMore',
-                  'spellcheck': True,
                 },
-              },
+              ],
+            },
+            'text': 'Yes',
+            'value': 'True',
+          },
+          <class 'dict'> {
+            'text': 'No',
+            'value': 'False',
+          },
+        ],
+        'name': 'yesNo',
+      },
+    },
+  ]
+---
+# name: TestDmMultiquestion.test_from_question_with_multiple_followups
+  <class 'list'> [
+  '
+      <span class="dm-question-advice">
+      This is some question advice
+      </span>
+    ',
+    <class 'dict'> {
+      'fieldset': <class 'dict'> {
+        'legend': <class 'dict'> {
+          'classes': 'govuk-fieldset__legend--m',
+          'text': 'Yes or no?',
+        },
+      },
+      'macro_name': 'govukRadios',
+      'params': <class 'dict'> {
+        'idPrefix': 'input-yesNo',
+        'items': <class 'list'> [
+          <class 'dict'> {
+            'conditional': <class 'dict'> {
+              'html': <class 'list'> [
+                <class 'dict'> {
+                  'label': <class 'dict'> {
+                    'for': 'input-tellUsMore',
+                    'text': 'Tell us more',
+                  },
+                  'macro_name': 'govukCharacterCount',
+                  'params': <class 'dict'> {
+                    'hint': <class 'dict'> {
+                      'text': 'Enter at least one word, and no more than 100',
+                    },
+                    'id': 'input-tellUsMore',
+                    'maxwords': 100,
+                    'name': 'tellUsMore',
+                    'spellcheck': True,
+                  },
+                },
+                <class 'dict'> {
+                  'label': <class 'dict'> {
+                    'for': 'input-letUsContactYou',
+                    'text': 'Enter your email so we can ask you to tell us even more',
+                  },
+                  'macro_name': 'govukInput',
+                  'params': <class 'dict'> {
+                    'classes': 'app-text-input--height-compatible',
+                    'hint': <class 'dict'> {
+                      'text': 'Enter an email, like bob@example.com',
+                    },
+                    'id': 'input-letUsContactYou',
+                    'name': 'letUsContactYou',
+                  },
+                },
+              ],
+            },
+            'text': 'Yes',
+            'value': 'True',
+          },
+          <class 'dict'> {
+            'text': 'No',
+            'value': 'False',
+          },
+        ],
+        'name': 'yesNo',
+      },
+    },
+  ]
+---
+# name: TestDmMultiquestion.test_from_question_with_multiple_followups_with_data
+  <class 'list'> [
+  '
+      <span class="dm-question-advice">
+      This is some question advice
+      </span>
+    ',
+    <class 'dict'> {
+      'fieldset': <class 'dict'> {
+        'legend': <class 'dict'> {
+          'classes': 'govuk-fieldset__legend--m',
+          'text': 'Yes or no?',
+        },
+      },
+      'macro_name': 'govukRadios',
+      'params': <class 'dict'> {
+        'idPrefix': 'input-yesNo',
+        'items': <class 'list'> [
+          <class 'dict'> {
+            'checked': True,
+            'conditional': <class 'dict'> {
+              'html': <class 'list'> [
+                <class 'dict'> {
+                  'label': <class 'dict'> {
+                    'for': 'input-tellUsMore',
+                    'text': 'Tell us more',
+                  },
+                  'macro_name': 'govukCharacterCount',
+                  'params': <class 'dict'> {
+                    'hint': <class 'dict'> {
+                      'text': 'Enter at least one word, and no more than 100',
+                    },
+                    'id': 'input-tellUsMore',
+                    'maxwords': 100,
+                    'name': 'tellUsMore',
+                    'spellcheck': True,
+                    'value': "Gosh, there's a lot to say.",
+                  },
+                },
+                <class 'dict'> {
+                  'label': <class 'dict'> {
+                    'for': 'input-letUsContactYou',
+                    'text': 'Enter your email so we can ask you to tell us even more',
+                  },
+                  'macro_name': 'govukInput',
+                  'params': <class 'dict'> {
+                    'classes': 'app-text-input--height-compatible',
+                    'hint': <class 'dict'> {
+                      'text': 'Enter an email, like bob@example.com',
+                    },
+                    'id': 'input-letUsContactYou',
+                    'name': 'letUsContactYou',
+                    'value': 'bob@example.com',
+                  },
+                },
+              ],
+            },
+            'text': 'Yes',
+            'value': 'True',
+          },
+          <class 'dict'> {
+            'text': 'No',
+            'value': 'False',
+          },
+        ],
+        'name': 'yesNo',
+      },
+    },
+  ]
+---
+# name: TestDmMultiquestion.test_from_question_with_multiple_followups_with_errors
+  <class 'list'> [
+  '
+      <span class="dm-question-advice">
+      This is some question advice
+      </span>
+    ',
+    <class 'dict'> {
+      'fieldset': <class 'dict'> {
+        'legend': <class 'dict'> {
+          'classes': 'govuk-fieldset__legend--m',
+          'text': 'Yes or no?',
+        },
+      },
+      'macro_name': 'govukRadios',
+      'params': <class 'dict'> {
+        'idPrefix': 'input-yesNo',
+        'items': <class 'list'> [
+          <class 'dict'> {
+            'conditional': <class 'dict'> {
+              'html': <class 'list'> [
+                <class 'dict'> {
+                  'label': <class 'dict'> {
+                    'for': 'input-tellUsMore',
+                    'text': 'Tell us more',
+                  },
+                  'macro_name': 'govukCharacterCount',
+                  'params': <class 'dict'> {
+                    'errorMessage': <class 'dict'> {
+                      'text': 'Enter an answer.',
+                    },
+                    'hint': <class 'dict'> {
+                      'text': 'Enter at least one word, and no more than 100',
+                    },
+                    'id': 'input-tellUsMore',
+                    'maxwords': 100,
+                    'name': 'tellUsMore',
+                    'spellcheck': True,
+                  },
+                },
+                <class 'dict'> {
+                  'label': <class 'dict'> {
+                    'for': 'input-letUsContactYou',
+                    'text': 'Enter your email so we can ask you to tell us even more',
+                  },
+                  'macro_name': 'govukInput',
+                  'params': <class 'dict'> {
+                    'classes': 'app-text-input--height-compatible',
+                    'errorMessage': <class 'dict'> {
+                      'text': 'Enter an email',
+                    },
+                    'hint': <class 'dict'> {
+                      'text': 'Enter an email, like bob@example.com',
+                    },
+                    'id': 'input-letUsContactYou',
+                    'name': 'letUsContactYou',
+                  },
+                },
+              ],
             },
             'text': 'Yes',
             'value': 'True',


### PR DESCRIPTION
The question [modernSlaveryTurnover](https://github.com/alphagov/digitalmarketplace-frameworks/blob/main/frameworks/digital-outcomes-and-specialists-5/questions/declaration/modernSlaveryTurnover.yml) contains multiple, un-nested conditional questions.

We've (probably sensibly) allowed for only one conditional question.

This PR allows the `dm_multiquestion` function to create a list of conditional questions, and handles this case in the `render` function.

I've flagged this question as one which may benefit from some UR: https://trello.com/c/JPQmbdfD/9-better-way-of-handling-the-modern-slavery-question