### PR TITLE
Add 'invoke test-mypy' command

### DIFF
--- a/dmcontent/html.py
+++ b/dmcontent/html.py
@@ -15,7 +15,7 @@ Note: this code doesn't provide for formatting of assurance approach
 information, as that hasn't been used since G-Cloud 8.
 """
 
-from typing import List
+from typing import List, Dict
 
 from jinja2 import Markup, escape
 
@@ -87,7 +87,7 @@ def to_summary_list_rows(questions, *, filter_empty=True, **kwargs) -> List[dict
     ]
 
 
-def to_summary_list_row(question, *, action_link=None, **kwargs) -> List[dict]:
+def to_summary_list_row(question, *, action_link=None, **kwargs) -> Dict[str, dict]:
     """Convert a QuestionSummary into a row for govukSummaryList.
 
     This method expects a QuestionSummary.
@@ -106,7 +106,7 @@ def to_summary_list_row(question, *, action_link=None, **kwargs) -> List[dict]:
         else:
             question_value = to_html(question, **kwargs)
         if not question.is_empty:
-            output = {
+            return {
                 "key": {"text": question_label},
                 "value": {"html": question_value},
                 "actions": {
@@ -118,19 +118,17 @@ def to_summary_list_row(question, *, action_link=None, **kwargs) -> List[dict]:
                 }
             }
         else:
-            output = {
+            return {
                 "key": {"text": question_label},
                 "value": {"html": question_value}
             }
     else:
         question_label = question.label
         question_value = to_html(question, **kwargs)
-        output = {
+        return {
             "key": {"text": question_label},
             "value": {"html": question_value}
         }
-
-    return output
 
 
 def text_to_html(

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,5 +4,6 @@ pip-tools>=5.5.0
 
 flake8<3.8.0,>=3.7.7
 mock
+mypy
 pytest>=4.6.0
 syrupy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ entrypoints==0.3
     # via flake8
 flake8==3.7.9
     # via -r requirements-dev.in
-importlib-metadata==3.4.0
+importlib-metadata==3.10.0
     # via
     #   -c requirements.txt
     #   pluggy
@@ -31,6 +31,10 @@ mock==4.0.2
     # via -r requirements-dev.in
 more-itertools==8.4.0
     # via pytest
+mypy-extensions==0.4.3
+    # via mypy
+mypy==0.812
+    # via -r requirements-dev.in
 packaging==20.4
     # via pytest
 pip-tools==5.5.0
@@ -57,12 +61,15 @@ syrupy==0.6.1
     # via -r requirements-dev.in
 toml==0.10.1
     # via pytest
+typed-ast==1.4.2
+    # via mypy
 typing-extensions==3.7.4.3
     # via
     #   -c requirements.txt
     #   importlib-metadata
+    #   mypy
     #   syrupy
-zipp==3.4.0
+zipp==3.4.1
     # via
     #   -c requirements.txt
     #   importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ cryptography==3.3.2
 defusedxml==0.6.0
     # via odfpy
 digitalmarketplace-utils==57.0.0
-    # via sanitized-package
+    # via digitalmarketplace-content-loader
 docopt==0.6.2
     # via notifications-python-client
 docutils==0.15.2
@@ -46,13 +46,13 @@ flask-wtf==0.14.3
     # via digitalmarketplace-utils
 flask==1.0.4
     # via
+    #   digitalmarketplace-content-loader
     #   digitalmarketplace-utils
     #   flask-gzip
     #   flask-login
     #   flask-session
     #   flask-wtf
     #   gds-metrics
-    #   sanitized-package
 fleep==1.0.1
     # via digitalmarketplace-utils
 future==0.18.2
@@ -63,16 +63,18 @@ govuk-country-register==0.5.0
     # via digitalmarketplace-utils
 idna==2.10
     # via requests
+importlib-metadata==3.10.0
+    # via markdown
 inflection==0.5.1
-    # via sanitized-package
+    # via digitalmarketplace-content-loader
 itsdangerous==1.1.0
     # via
     #   flask
     #   flask-wtf
 jinja2==2.11.3
     # via
+    #   digitalmarketplace-content-loader
     #   flask
-    #   sanitized-package
 jmespath==0.10.0
     # via
     #   boto3
@@ -80,7 +82,7 @@ jmespath==0.10.0
 mailchimp3==3.0.6
     # via digitalmarketplace-utils
 markdown==3.3.4
-    # via sanitized-package
+    # via digitalmarketplace-content-loader
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -104,7 +106,7 @@ python-json-logger==0.1.11
 pytz==2020.1
     # via digitalmarketplace-utils
 pyyaml==5.4.1
-    # via sanitized-package
+    # via digitalmarketplace-content-loader
 redis==3.5.3
     # via digitalmarketplace-utils
 requests==2.24.0
@@ -118,6 +120,8 @@ six==1.15.0
     # via
     #   cryptography
     #   python-dateutil
+typing-extensions==3.7.4.3
+    # via importlib-metadata
 unicodecsv==0.14.1
     # via digitalmarketplace-utils
 urllib3==1.25.10
@@ -132,3 +136,5 @@ workdays==1.4
     # via digitalmarketplace-utils
 wtforms==2.3.3
     # via flask-wtf
+zipp==3.4.1
+    # via importlib-metadata

--- a/tasks.py
+++ b/tasks.py
@@ -1,1 +1,11 @@
+from invoke import task
+
 from dmdevtools.invoke_tasks import library_tasks as ns
+
+
+@task(ns["virtualenv"], ns["requirements_dev"])
+def test_mypy(c):
+    c.run("mypy dmcontent/")
+
+
+ns.add_task(test_mypy)


### PR DESCRIPTION
So that we can run mypy against this repo to check our types.

Don't add this to `invoke test` because it's currently very broken. Once we've fixed all the errors, we should add it to `invoke test`.

Also fix one wrong type hint I noticed.

This is the current output of `invoke test`:

```
mypy dmcontent/
dmcontent/html.py:22: error: Skipping analyzing 'dmutils.filters': found module but no type hints or library stubs
dmcontent/html.py:22: error: Skipping analyzing 'dmutils': found module but no type hints or library stubs
dmcontent/utils.py:7: error: Skipping analyzing 'dmutils.jinja2_environment': found module but no type hints or library stubs
dmcontent/govuk_frontend.py:54: error: Skipping analyzing 'dmutils.forms.errors': found module but no type hints or library stubs
dmcontent/govuk_frontend.py:54: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
dmcontent/govuk_frontend.py:55: error: Skipping analyzing 'dmutils.forms.helpers': found module but no type hints or library stubs
dmcontent/govuk_frontend.py:145: error: Incompatible return value type (got "List[Any]", expected "Optional[Dict[Any, Any]]")
dmcontent/govuk_frontend.py:275: error: Argument 1 to "Markup" has incompatible type "Optional[Any]"; expected "str"
dmcontent/govuk_frontend.py:366: error: Argument 1 to "append" of "list" has incompatible type "Optional[Dict[Any, Any]]"; expected "Markup"
dmcontent/govuk_frontend.py:376: error: Invalid index type "str" for "Markup"; expected type "Union[int, slice]"
dmcontent/govuk_frontend.py:379: error: Invalid index type "str" for "str"; expected type "Union[int, slice]"
dmcontent/govuk_frontend.py:380: error: Invalid index type "str" for "str"; expected type "Union[int, slice]"
dmcontent/govuk_frontend.py:381: error: Unsupported target for indexed assignment ("str")
dmcontent/govuk_frontend.py:401: error: Incompatible types in assignment (expression has type "bool", target has type "str")
dmcontent/govuk_frontend.py:422: error: Incompatible types in assignment (expression has type "bool", target has type "str")
dmcontent/govuk_frontend.py:515: error: Incompatible types in assignment (expression has type "Dict[str, str]", target has type "str")
dmcontent/govuk_frontend.py:517: error: Unsupported target for indexed assignment ("str")
dmcontent/questions.py:7: error: Skipping analyzing 'dmutils.formats': found module but no type hints or library stubs
dmcontent/questions.py:34: error: "object" has no attribute "_context"
dmcontent/questions.py:36: error: Incompatible return value type (got "object", expected "Optional[Question]")
dmcontent/questions.py:269: error: "Question" has no attribute "questions"; maybe "get_question"?
dmcontent/questions.py:337: error: "Question" has no attribute "questions"; maybe "get_question"?
dmcontent/questions.py:444: error: Incompatible return value type (got "Dict[<nothing>, <nothing>]", expected "OrderedDict[Any, Any]")
dmcontent/questions.py:575: error: Return type "HierarchySummary" of "summary" incompatible with return type "ListSummary" in supertype "List"
dmcontent/questions.py:750: error: Definition of "get_error_messages" in base class "QuestionSummary" is incompatible with definition in base class "Multiquestion"
dmcontent/questions.py:800: error: Definition of "get_error_messages" in base class "QuestionSummary" is incompatible with definition in base class "DynamicList"
dmcontent/questions.py:800: error: Definition of "get_error_messages" in base class "QuestionSummary" is incompatible with definition in base class "Multiquestion"
dmcontent/content_loader.py:119: error: Need type annotation for 'new_sections'
dmcontent/content_loader.py:436: error: Need type annotation for 'filtered_questions' (hint: "filtered_questions: List[<type>] = ...")
dmcontent/content_loader.py:522: error: Return value expected
Found 29 errors in 5 files (checked 12 source files)
```