### PR TITLE
Fix type hints in dmcontent/govuk_frontend.py

### DIFF
--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -46,7 +46,7 @@ Read the docstring for `from_question()` for more detail on how Questions are
 handled.
 """
 
-from typing import List, Optional, Set, TYPE_CHECKING
+from typing import List, Optional, Set, Union, TYPE_CHECKING
 
 import jinja2
 from jinja2 import Markup, escape
@@ -67,7 +67,7 @@ govuk_frontend_version = (2, 13, 0)
 
 def from_question(
     question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
-) -> Optional[dict]:
+) -> Union[dict, List[dict], None]:
     """Create parameters object for govuk-frontend macros from a question
 
     `from_question()` takes a `Question` and returns a dict containing the name of
@@ -346,7 +346,7 @@ def dm_pricing_input(
 
 def dm_multiquestion(
     question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
-) -> list:
+) -> List[dict]:
     to_render = []
 
     if question.get("question_advice"):

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -521,9 +521,10 @@ def _params(
         params["classes"] = " ".join(classes)
 
     if hint_text:
-        params["hint"] = {"text": hint_text}
+        hint = {"text": hint_text}
         if kwargs.get("hint_classes"):
-            params["hint"]["classes"] = " ".join(kwargs["hint_classes"])
+            hint["classes"] = " ".join(kwargs["hint_classes"])
+        params["hint"] = hint
 
     if data and data.get(input_id):
         params["value"] = data[input_id]

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -512,7 +512,7 @@ def _params(
     hint_text: Optional[str] = kwargs.get("hint_text", question.get("hint"))
     input_id: str = kwargs.get("input_id", question.id)
 
-    params = {
+    params: Dict[str, Union[str, dict]] = {
         "id": f"input-{input_id}",
         "name": input_id,
     }

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -64,12 +64,12 @@ __all__ = ["render_question", "from_question", "govuk_input", "govuk_label"]
 # set this in your app to change the behaviour of this code.
 govuk_frontend_version = (2, 13, 0)
 
-MultiQuestionToRender = List[Union[dict, Markup]]
+Renderable = Union[dict, str, Markup, List[Union[dict, str, Markup]]]
 
 
 def from_question(
     question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
-) -> Union[dict, MultiQuestionToRender]:
+) -> Renderable:
     """Create parameters object for govuk-frontend macros from a question
 
     `from_question()` takes a `Question` and returns a dict containing the name of
@@ -348,8 +348,8 @@ def dm_pricing_input(
 
 def dm_multiquestion(
     question: 'Question', data: Optional[dict] = None, errors: Optional[dict] = None, **kwargs
-) -> MultiQuestionToRender:
-    to_render: MultiQuestionToRender = []
+) -> Renderable:
+    to_render: List[Union[dict, Markup, str]] = []
 
     if question.get("question_advice"):
         to_render.append(_question_advice(question))
@@ -553,7 +553,7 @@ def _question_advice(
 # and experiment a bit more.
 
 @jinja2.contextfunction
-def render(ctx, obj, *, question=None) -> Markup:
+def render(ctx, obj: Renderable, *, question=None) -> Markup:
     """Call Jinja2 macros using Python objects
 
     We want to be able to create HTML using govuk-frontend macros within Python

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -46,7 +46,7 @@ Read the docstring for `from_question()` for more detail on how Questions are
 handled.
 """
 
-from typing import cast, List, Optional, Set, Union, TYPE_CHECKING
+from typing import cast, Dict, List, Optional, Set, Union, TYPE_CHECKING
 
 import jinja2
 from jinja2 import Markup, escape
@@ -392,14 +392,14 @@ def dm_multiquestion(
     return to_render
 
 
-def govuk_label(question: 'Question', *, is_page_heading: bool = True, **kwargs) -> dict:
+def govuk_label(question: 'Question', *, is_page_heading: bool = True, **kwargs) -> Dict[str, Union[str, bool]]:
     """
     :param bool is_page_heading: If True, the label will be set to display as a page heading
     """
     input_id: str = kwargs.get("input_id", question.id)
     label_classes: List[str] = kwargs.get("label_classes", [])
 
-    label = {
+    label: Dict[str, Union[str, bool]] = {
         "for": f"input-{input_id}",
         "text": get_label_text(question, **kwargs),
     }
@@ -413,12 +413,14 @@ def govuk_label(question: 'Question', *, is_page_heading: bool = True, **kwargs)
     return label
 
 
-def govuk_fieldset(question: 'Question', *, is_page_heading: bool = True, **kwargs) -> dict:
+def govuk_fieldset(
+        question: 'Question', *, is_page_heading: bool = True, **kwargs
+) -> Dict[str, Dict[str, Union[str, bool]]]:
     """
     :param bool is_page_heading: If True, the legend will be set to display as a page heading
     """
 
-    fieldset = {
+    fieldset: Dict[str, Dict[str, Union[str, bool]]] = {
         "legend": {
             "classes": "govuk-fieldset__legend--m",
             "text": get_label_text(question),

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -273,7 +273,7 @@ def govuk_file_upload(
     # add a line to the hint text rather than pre-filling the input
     if data and data.get(params["name"]):
         params["hint"]["html"] += Markup("<p>Previously uploaded file:<br>")
-        params["hint"]["html"] += Markup(data.get(params["name"]))
+        params["hint"]["html"] += Markup(str(data.get(params["name"])))
         params["hint"]["html"] += Markup("</p>")
 
     # Set an empty key in params for `question_advice` so `render` doesn't


### PR DESCRIPTION
Trello: https://trello.com/c/DZ28pqhm/90-try-to-add-type-hints-to-content-loader

Content loader is quite complex. We'd like to use mypy to check that we're not doing anything wrong. This PR is a pre-requisite that fixes the existing mypy failures in `dmcontent/govuk_frontend.py`.

We've not changed the type signature or behaviour of any methods used by the frontend apps. So this should have no effect outside this repo.

See individual commits for details of what (and why) this PR does.