### PR TITLE
Fix type hints in dmcontent/questions.py

### DIFF
--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -12,7 +12,8 @@ from .formats import format_price
 from .govuk_frontend import get_href
 from .utils import TemplateField, drop_followups, get_option_value
 
-T = TypeVar("T", bound="Question")
+TQuestion = TypeVar("TQuestion", bound="Question")
+TMultiquestion = TypeVar("TMultiquestion", bound="Multiquestion")
 
 
 class Question(object):
@@ -28,7 +29,7 @@ class Question(object):
     def summary(self, service_data, inplace_allowed: bool = False) -> "QuestionSummary":
         return QuestionSummary(self, service_data)
 
-    def filter(self: T, context, dynamic=True, inplace_allowed: bool = False) -> Optional[T]:
+    def filter(self: TQuestion, context, dynamic=True, inplace_allowed: bool = False) -> Optional[TQuestion]:
         if not self._should_be_shown(context):
             return None
 
@@ -41,7 +42,7 @@ class Question(object):
                 raise TypeError(f"The question's type did not match its type data. "
                                 f"Got {type(content_question)}, expected {type(self)}")
 
-            return cast(T, content_question)
+            return cast(TQuestion, content_question)
 
     def _should_be_shown(self, context):
         return all(
@@ -269,7 +270,7 @@ class Multiquestion(Question):
     def summary(self, service_data, inplace_allowed: bool = False) -> "MultiquestionSummary":
         return MultiquestionSummary(self, service_data)
 
-    def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> Optional["Question"]:
+    def filter(self: TMultiquestion, context, dynamic=True, inplace_allowed: bool = False) -> Optional[TMultiquestion]:
         multi_question = super(Multiquestion, self).filter(context, dynamic=dynamic, inplace_allowed=inplace_allowed)
         if not multi_question:
             return None

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -2,7 +2,7 @@ from collections import OrderedDict, defaultdict
 from datetime import datetime
 import re
 
-from typing import Optional, TypeVar, cast
+from typing import Optional, TypeVar
 
 from dmutils.formats import DATE_FORMAT, DISPLAY_DATE_FORMAT
 
@@ -37,12 +37,7 @@ class Question(object):
             self._context = context
             return self
         else:
-            content_question = ContentQuestion(self._data, number=self.number, _context=context)
-            if not type(self) == type(content_question):
-                raise TypeError(f"The question's type did not match its type data. "
-                                f"Got {type(content_question)}, expected {type(self)}")
-
-            return cast(TQuestion, content_question)
+            return self.__class__(self._data, number=self.number, _context=context)
 
     def _should_be_shown(self, context):
         return all(

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -328,7 +328,7 @@ class DynamicList(Multiquestion):
         super(DynamicList, self).__init__(data, *args, **kwargs)
         self.type = 'multiquestion'  # same UI components as Multiquestion
 
-    def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> Optional["Question"]:
+    def filter(self, context, dynamic=True, inplace_allowed: bool = False) -> Optional["DynamicList"]:
         if not dynamic:
             return super(DynamicList, self).filter(context, dynamic=dynamic, inplace_allowed=inplace_allowed)
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -111,12 +111,12 @@ class Question(object):
 
         return {self.id: value}
 
-    def get_error_messages(self, errors: dict, question_descriptor_from: str = "label") -> dict:
+    def get_error_messages(self, errors: dict, question_descriptor_from: str = "label") -> OrderedDict:
         error_fields = set(errors.keys()) & set(self.form_fields)
         if not error_fields:
-            return {}
+            return OrderedDict()
 
-        question_errors = {}
+        question_errors = OrderedDict()
         for field_name in sorted(error_fields):
             question = self.get_question(field_name)
             message_key = errors[field_name]
@@ -660,7 +660,7 @@ class QuestionSummary(Question):
     def _default_for_field(self, field_key):
         return self.get('field_defaults', {}).get(field_key)
 
-    def get_error_messages(self, errors: dict, question_descriptor_from: str = "label") -> dict:
+    def get_error_messages(self, errors: dict, question_descriptor_from: str = "label") -> OrderedDict:
 
         question_errors = super(QuestionSummary, self).get_error_messages(
             errors,

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -258,7 +258,7 @@ class Multiquestion(Question):
         super(Multiquestion, self).__init__(data, *args, **kwargs)
 
         self.questions = [
-            question if isinstance(question, ContentQuestion) else ContentQuestion(question)
+            ContentQuestion(question)
             for question in data['questions']
         ]
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -557,7 +557,7 @@ class List(Question):
 
         return {self.id: value or None}
 
-    def summary(self, service_data, inplace_allowed: bool = False) -> "ListSummary":
+    def summary(self, service_data, inplace_allowed: bool = False) -> 'QuestionSummary':
         return ListSummary(self, service_data)
 
 
@@ -581,7 +581,7 @@ class Hierarchy(List):
 
         return {self.id: sorted(values) or None}
 
-    def summary(self, service_data, inplace_allowed: bool = False) -> "HierarchySummary":
+    def summary(self, service_data, inplace_allowed: bool = False) -> 'QuestionSummary':
         return HierarchySummary(self, service_data)
 
     def get_missing_values(self, selected_values_set):

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -450,7 +450,7 @@ class DynamicList(Multiquestion):
 
     def get_error_messages(self, errors: dict, question_descriptor_from: str = "label") -> OrderedDict:
         if self.id not in errors:
-            return {}
+            return OrderedDict()
 
         # Assumes errors being passed in are ordered by 'index' key e.g.
         # {'example': [

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -2,7 +2,7 @@ from collections import OrderedDict, defaultdict
 from datetime import datetime
 import re
 
-from typing import Optional, TypeVar, Type, Union, cast
+from typing import Optional, TypeVar, cast
 
 from dmutils.formats import DATE_FORMAT, DISPLAY_DATE_FORMAT
 

--- a/dmcontent/questions.py
+++ b/dmcontent/questions.py
@@ -30,10 +30,11 @@ class Question(object):
         if not self._should_be_shown(context):
             return None
 
-        question = self if inplace_allowed else ContentQuestion(self._data, number=self.number)
-        question._context = context
-
-        return question
+        if inplace_allowed:
+            self._context = context
+            return self
+        else:
+            return ContentQuestion(self._data, number=self.number, _context=context)
 
     def _should_be_shown(self, context):
         return all(
@@ -915,7 +916,7 @@ QUESTION_TYPES = {
 }
 
 
-class ContentQuestion(object):
+class ContentQuestion(Question):
     def __new__(cls, data, *args, **kwargs):
         if data.get('type') in QUESTION_TYPES:
             return QUESTION_TYPES[data['type']](data, *args, **kwargs)

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -202,6 +202,12 @@ class TestText(QuestionTest):
     def test_get_question_ids_by_type(self):
         assert self.question().get_question_ids(type='text') == ['example']
 
+    def test_question_filter_is_correct_type(self):
+        question = self.question(depends=[{"on": "lot", "being": ["lot-1"]}])
+        question._data["type"] = "list"
+        with pytest.raises(TypeError):
+            question.filter(self.context({"lot": "lot-1"}))
+
 
 class TestDates(QuestionTest):
     def question(self, **kwargs):

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -202,12 +202,6 @@ class TestText(QuestionTest):
     def test_get_question_ids_by_type(self):
         assert self.question().get_question_ids(type='text') == ['example']
 
-    def test_question_filter_is_correct_type(self):
-        question = self.question(depends=[{"on": "lot", "being": ["lot-1"]}])
-        question._data["type"] = "list"
-        with pytest.raises(TypeError):
-            question.filter(self.context({"lot": "lot-1"}))
-
 
 class TestDates(QuestionTest):
     def question(self, **kwargs):


### PR DESCRIPTION
Trello: https://trello.com/c/DZ28pqhm/90-try-to-add-type-hints-to-content-loader

Content loader is quite complex. We'd like to use mypy to check that we're not doing anything wrong. This PR is a pre-requisite that fixes the existing mypy failures in `dmcontent/questions.py`.

This is slightly more complex than #146 in that we've used `TypeVars` to show that methods on the base classes can be called by subclasses and return the type of the sub class. This is similar to the way typing is done for generics - the [mypy docs](https://mypy.readthedocs.io/en/stable/generics.html) have a pretty good explanation.

See individual commits for details of what (and why) this PR does.