### PR TITLE
Fix type hints in dmcontent/content_loader.py

### DIFF
--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -116,10 +116,10 @@ class ContentManifest(object):
         Only includes the questions that should be shown for the provided
         service data. This is calculated by resolving the dependencies
         described by the `depends` section."""
-        new_sections = filter(None, [
+        new_sections: List[ContentSection] = list(filter(None, [
             section.filter(context, dynamic=dynamic, inplace_allowed=inplace_allowed)
             for section in self.sections
-        ])
+        ]))
 
         if inplace_allowed:
             self.sections[:] = new_sections
@@ -433,7 +433,7 @@ class ContentSection(object):
         section = self if inplace_allowed else self.copy()
         section._context = context
 
-        filtered_questions = list(filter(None, [
+        filtered_questions: List[Question] = list(filter(None, [
             question.filter(context, dynamic=dynamic, inplace_allowed=inplace_allowed)
             for question in self.questions
         ]))

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -519,7 +519,7 @@ class ContentLoader(object):
 
     def load_manifest(self, framework_slug, question_set, manifest) -> Optional[List]:
         if manifest in self._content[framework_slug]:
-            return
+            return None
 
         self._content[framework_slug][manifest] = self.generate_manifest(framework_slug, question_set, manifest)
         return self._content[framework_slug][manifest]


### PR DESCRIPTION
Trello: https://trello.com/c/DZ28pqhm/90-try-to-add-type-hints-to-content-loader

Content loader is quite complex. We'd like to use mypy to check that we're not doing anything wrong. This PR is a pre-requisite that fixes the existing mypy failures in `dmcontent/questions.py`.

