### PR TITLE
Mark this package as having type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Records breaking changes from major version bumps
 
+## 8.0.0
+
+PR [#149](https://github.com/alphagov/digitalmarketplace-content-loader/pull/149)
+marks this package as PEP 561 compliant. If you have dmcontent as a dependency and run type checking, the type checker
+will now check that you're using dmcontent correctly. This might break your application's type checking if you're using 
+dmcontent incorrectly. 
+
 ## 7.0.0
 
 PR [#71](https://github.com/alphagov/digitalmarketplace-content-loader/pull/71)

--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '7.34.0'
+__version__ = '8.0.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ cryptography==3.3.2
     # via digitalmarketplace-utils
 defusedxml==0.6.0
     # via odfpy
-digitalmarketplace-utils==57.0.0
+digitalmarketplace-utils==58.0.0
     # via digitalmarketplace-content-loader
 docopt==0.6.2
     # via notifications-python-client

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     description='Digital Marketplace Content Loader',
     long_description=__doc__,
     packages=find_packages(),
+    package_data={'dmcontent': ['py.typed']},
     include_package_data=True,
     install_requires=[
         'Flask<1.1.0,>=1.0.2',

--- a/tasks.py
+++ b/tasks.py
@@ -9,3 +9,4 @@ def test_mypy(c):
 
 
 ns.add_task(test_mypy)
+ns["test"].pre.insert(-1, test_mypy)


### PR DESCRIPTION
Trello: https://trello.com/c/DZ28pqhm/90-try-to-add-type-hints-to-content-loader

As per [PEP 561](https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages), we need to let type checkers know that this package has type hints. We do this by adding an empty `py.typed` file, and adding it to `setup.py`.

mypy will now recognise that this package is typed. So it will check the types when type checking things that depend on `dmcontent`.

Very similar to https://github.com/alphagov/digitalmarketplace-utils/pull/606