### PR TITLE
Add default max items for list input

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '8.1.0'
+__version__ = '8.1.1'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -295,7 +295,7 @@ def dm_list_input(
 
     # Params that are not common to other components
     params["addButtonName"] = "item"
-    params["maxItems"] = question.number_of_items
+    params["maxItems"] = question.get('number_of_items', 10)
     params["items"] = []
     params["itemLabelPrefix"] = str(question.question)
 


### PR DESCRIPTION
`dmListInput` requires `maxItems` to be defined in order to render the correct number of inputs.

On Supplier Frontend, we have some questions that do not define `number_of_items` since the Frontend Toolkit forms macro passed a default of 10 into the old List Entry component.

Rather than hunting down all the questions that do this and adding `number_of_items` to each, we can pass the same default here.