### PR TITLE
Add get_question_as_section_containing_itself

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '8.1.1'
+__version__ = '8.2.0'

--- a/dmcontent/content_loader.py
+++ b/dmcontent/content_loader.py
@@ -226,6 +226,22 @@ class ContentSection(object):
             _context=self._context
         )
 
+    def get_question_as_section_containing_itself(self, question_slug):
+        question = self.get_question_by_slug(question_slug)
+        if not question:
+            return None
+
+        return ContentSection(
+            slug=question.slug,
+            name=question.label,
+            prefill=self.prefill,
+            editable=self.edit_questions,
+            edit_questions=False,
+            questions=[question],
+            description=question.get('hint') if question.get('questions') else '',
+            _context=self._context
+        )
+
     def get_field_names(self):
         """Return a list of field names that this section returns
 


### PR DESCRIPTION
We use the digitalmarketplace-content-loader `render_question` method  to render forms across our frontend apps.

This method expects a single question as input, but in some cases we're using `get_question_as_section` to convert
Questions to ContentSections. This has the side-effect of removing information about the question itself. For
example, we lose the `type` property.

To deal with this, we've created a new method which retains this question information so that we can access it normally.