### PR TITLE
Fix bug when generating list HTML

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '8.2.0'
+__version__ = '8.2.1'

--- a/dmcontent/markdown.py
+++ b/dmcontent/markdown.py
@@ -21,8 +21,15 @@ class _ClassAddingTreeprocessor(Treeprocessor):
 
         # mutate each affected element in-place
         if element.tag in self._mapping:
-            orig_class = element.attrib.get("class", "")
-            element.set("class", (orig_class + " " if orig_class else "") + self._mapping[element.tag])
+            if not self.is_html_placeholder(element):
+                orig_class = element.attrib.get("class", "")
+                element.set("class", (orig_class + " " if orig_class else "") + self._mapping[element.tag])
+
+    def is_html_placeholder(self, element: Element):
+        """Check if this element is one that's been added as a placeholder for some raw html by
+        markdown.preprocessors.HtmlBlockPreprocessor."""
+        placeholders = [self.md.htmlStash.get_placeholder(i) for i in range(self.md.htmlStash.html_counter)]
+        return element.tag == "p" and element.text in placeholders
 
 
 class GOVUKFrontendExtension(Extension):

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -34,3 +34,8 @@ Paragraphs, and [links](#).
         text = '<a href="#" target="_blank" rel="noopener noreferrer">link (opens in new tab)</a>'
 
         assert text in markdown.markdown(text, extensions=[GOVUKFrontendExtension()])
+
+    def test_list(self):
+        text = '<ul><li>A text</li></ul>'
+
+        assert 'p' not in markdown.markdown(text, extensions=[GOVUKFrontendExtension()])


### PR DESCRIPTION
Fix a bug where invalid HTML was generated when a HTML list was put in one of a question's Markdown fields (eg. `essentialRequirementsMet`[1])

This was because the markdown preprocessor (`markdown.preprocessors.HtmlBlockPreprocessor`) replaces raw HTML content with a placeholder value wrapped in an empty `<p></p>`. There is a postprocessor (`markdown.postprocessors.RawHtmlPostprocessor`) that finds the placeholders and removes the empty `<p></p>`, however we have a custom [`Treeprocessor`](https://github.com/alphagov/digitalmarketplace-content-loader/blob/main/dmcontent/markdown.py#L8) which added on the `govuk-body` class to these empty `<p>` tags and meant that they weren't removed by the post processor.

This meant that we had list elements wrapped in `<p>` tags in the output HTML which isn't valid HTML.

Add a check to `dmcontent.markdown._ClassAddingTreeprocessor` that ensures it doesn't add classes to these placeholder elements.

[1]:https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/digital-outcomes-and-specialists-5/questions/brief-responses/essentialRequirementsMet.yml

https://trello.com/c/OMcXpf8k/42-2-content-loader-can-generate-invalid-list-html