### PR TITLE
Unblock upgrade of urllib3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,11 @@ entrypoints==0.3
     # via flake8
 flake8==3.7.9
     # via -r requirements-dev.in
+importlib-metadata==4.6.0
+    # via
+    #   -c requirements.txt
+    #   pluggy
+    #   pytest
 iniconfig==1.0.1
     # via pytest
 mccabe==0.6.1
@@ -58,11 +63,16 @@ toml==0.10.1
     # via pytest
 typed-ast==1.4.2
     # via mypy
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via
     #   -c requirements.txt
+    #   importlib-metadata
     #   mypy
     #   syrupy
+zipp==3.4.1
+    # via
+    #   -c requirements.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@
     # via -r requirements.in
 blinker==1.4
     # via gds-metrics
-boto3==1.14.56
+boto3==1.17.101
     # via digitalmarketplace-utils
-botocore==1.17.56
+botocore==1.20.101
     # via
     #   boto3
     #   s3transfer
@@ -31,11 +31,9 @@ cryptography==3.3.2
 defusedxml==0.6.0
     # via odfpy
 digitalmarketplace-utils==59.1.0
-    # via sanitized-package
+    # via digitalmarketplace-content-loader
 docopt==0.6.2
     # via notifications-python-client
-docutils==0.15.2
-    # via botocore
 flask-gzip==0.2
     # via digitalmarketplace-utils
 flask-login==0.5.0
@@ -46,13 +44,13 @@ flask-wtf==0.14.3
     # via digitalmarketplace-utils
 flask==1.1.4
     # via
+    #   digitalmarketplace-content-loader
     #   digitalmarketplace-utils
     #   flask-gzip
     #   flask-login
     #   flask-session
     #   flask-wtf
     #   gds-metrics
-    #   sanitized-package
 fleep==1.0.1
     # via digitalmarketplace-utils
 future==0.18.2
@@ -63,16 +61,18 @@ govuk-country-register==0.5.0
     # via digitalmarketplace-utils
 idna==2.10
     # via requests
+importlib-metadata==4.6.0
+    # via markdown
 inflection==0.5.1
-    # via sanitized-package
+    # via digitalmarketplace-content-loader
 itsdangerous==1.1.0
     # via
     #   flask
     #   flask-wtf
 jinja2==2.11.3
     # via
+    #   digitalmarketplace-content-loader
     #   flask
-    #   sanitized-package
 jmespath==0.10.0
     # via
     #   boto3
@@ -80,7 +80,7 @@ jmespath==0.10.0
 mailchimp3==3.0.14
     # via digitalmarketplace-utils
 markdown==3.3.4
-    # via sanitized-package
+    # via digitalmarketplace-content-loader
 markupsafe==1.1.1
     # via
     #   jinja2
@@ -104,23 +104,25 @@ python-json-logger==0.1.11
 pytz==2020.1
     # via digitalmarketplace-utils
 pyyaml==5.4.1
-    # via sanitized-package
+    # via digitalmarketplace-content-loader
 redis==3.5.3
     # via digitalmarketplace-utils
-requests==2.24.0
+requests==2.25.1
     # via
     #   digitalmarketplace-utils
     #   mailchimp3
     #   notifications-python-client
-s3transfer==0.3.3
+s3transfer==0.4.2
     # via boto3
 six==1.15.0
     # via
     #   cryptography
     #   python-dateutil
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 unicodecsv==0.14.1
     # via digitalmarketplace-utils
-urllib3==1.25.10
+urllib3==1.26.6
     # via
     #   botocore
     #   requests
@@ -130,3 +132,5 @@ workdays==1.4
     # via digitalmarketplace-utils
 wtforms==2.3.3
     # via flask-wtf
+zipp==3.4.1
+    # via importlib-metadata


### PR DESCRIPTION
There are a few dependencies that were getting a bit old. This was because they could only be upgraded together. This meant that Dependabot couldn't cope, because it wants to only upgrade one thing at a time.

Fixes a moderate-severity issue reported by Dependabot: https://github.com/alphagov/digitalmarketplace-content-loader/security/dependabot/requirements.txt/urllib3/open