### PR TITLE
Fix bug when number field value is 0

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '8.2.1'
+__version__ = '8.2.2'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -158,6 +158,9 @@ def govuk_input(
     params = _params(question, data, errors, **kwargs)
 
     if question.type in ("number", "pricing"):
+        # If value is 0, it can get evaluated as False, so we should stringify it
+        if isinstance(params.get("value"), int):
+            params["value"] = str(params["value"])
         params["classes"] += " govuk-input--width-5"
         params["spellcheck"] = False
         if question.get("limits") and question.limits.get("integer_only") is True:
@@ -526,7 +529,7 @@ def _params(
             hint["classes"] = " ".join(kwargs["hint_classes"])
         params["hint"] = hint
 
-    if data and data.get(input_id):
+    if data and data.get(input_id) is not None:
         params["value"] = data[input_id]
 
     if errors and errors.get(input_id):

--- a/tests/__snapshots__/test_govuk_frontend.ambr
+++ b/tests/__snapshots__/test_govuk_frontend.ambr
@@ -1139,6 +1139,24 @@
     'spellcheck': False,
   }
 ---
+# name: TestNumberInput.test_from_question_with_answer_being_zero
+  <class 'dict'> {
+    'label': <class 'dict'> {
+      'classes': 'govuk-label--l',
+      'for': 'input-howMany',
+      'isPageHeading': True,
+      'text': 'How many?',
+    },
+    'macro_name': 'govukInput',
+    'params': <class 'dict'> {
+      'classes': 'app-text-input--height-compatible govuk-input--width-5',
+      'id': 'input-howMany',
+      'name': 'howMany',
+      'spellcheck': False,
+      'value': '0',
+    },
+  }
+---
 # name: TestNumberInput.test_from_question_with_data
   <class 'dict'> {
     'label': <class 'dict'> {

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -189,6 +189,14 @@ class TestNumberInput:
         assert form["params"]["value"] == "10"
         assert form == snapshot
 
+    def test_from_question_with_answer_being_zero(self, question, snapshot):
+        data = {"howMany": 0}
+
+        form = from_question(question, data)
+
+        assert form["params"]["value"] == "0"
+        assert form == snapshot
+
     def test_from_question_with_errors(self, question, snapshot):
         errors = {
             "howMany": {


### PR DESCRIPTION
In some cases, we may pass 0 in a govukInput field and expect it to be a valid answer.

This doesn't display as Jinja evaluates 0 as falsy in the template: https://github.com/alphagov/govuk-frontend/blob/b2687fe47f3eb37d8790f422edb520fc24b4e0cd/src/govuk/components/input/template.njk#L51

We can fix this by stringifying `int`s for govukInputs, since we're using an input of `type='text'` anyway.