### PR TITLE
Update responsible security vulnerability disclosure to CCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Digital Marketplace Content Loader
 
 Content loader for Digital Marketplace.
 
-Originally was part of [Digital Marketplace Utils](https://github.com/alphagov/digitalmarketplace-utils).
+Originally was part of [Digital Marketplace Utils](https://github.com/Crown-Commercial-Service/digitalmarketplace-utils).
 
 
 ## Running the tests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+Contact: cybersecurity@crowncommercial.gov.uk
+
+Policy: https://www.crowncommercial.gov.uk/vulnerability-disclosure-policy
+
+Acknowledgements: https://www.crowncommercial.gov.uk/vulnerability-disclosure-policy/acknowledgements
+
+Encryption: https://github.com/Crown-Commercial-Service/ccs-vulnerability-disclosure-policy/blob/main/vulnerability-disclosure-public-encryption.pub


### PR DESCRIPTION
https://trello.com/c/yXyu5sA6/180-update-links-for-reporting-security-vulnerabilities

Update responsible security vulnerability disclosure for repo now DM has transitioned to CCS